### PR TITLE
Status messages

### DIFF
--- a/src/wiln_node.cpp
+++ b/src/wiln_node.cpp
@@ -396,7 +396,7 @@ private:
 
         recording = false;
 
-        publishStatus("IDLE:STOPPED");
+        publishStatus("IDLE: Stopped Recording");
 
         return;
     }
@@ -405,7 +405,7 @@ private:
     {
         plannedTrajectory.paths.clear();
 
-        publishStatus("IDLE:CLEARED TRAJECTORY");
+        publishStatus("IDLE: Cleared Trajectory");
 
         return;
     }
@@ -413,6 +413,7 @@ private:
     void smoothTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
     {
         plannedTrajectory = smoothTrajectoryLowPass(plannedTrajectory);
+        RCLCPP_INFO(this->get_logger(), "Trajectory has been smoothened");
         return;
     }
 
@@ -425,7 +426,7 @@ private:
         }
 
         playing = false;
-        publishStatus("IDLE:CANCELED TRAJECTORY");
+        publishStatus("IDLE: Canceled Trajectory");
 
         // TODO: validate action call here
         followPathClient->async_cancel_all_goals();
@@ -645,12 +646,14 @@ private:
     void loadLTRServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)
     {
         loadLTR(req->file_name.data, false);
+        publishStatus("IDLE: Loaded LTR");
         return;
     }
 
     void loadLTRFromEndServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)
     {
         loadLTR(req->file_name.data, true);
+        publishStatus("IDLE: Loaded LTR From End");
         return;
     }
 
@@ -801,6 +804,7 @@ private:
         }
 
         playing = true;
+        publishStatus("REPEATING: Loop");
 
         realTrajectory.paths.clear();
 

--- a/src/wiln_node.cpp
+++ b/src/wiln_node.cpp
@@ -5,6 +5,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <string>
 
 #include <wiln/srv/save_map_traj.hpp>
 #include <wiln/srv/load_map_traj.hpp>
@@ -16,6 +17,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
+#include <std_msgs/msg/string.hpp>
 
 #include <norlab_controllers_msgs/msg/directional_path.hpp>
 #include <norlab_controllers_msgs/msg/path_sequence.hpp>
@@ -92,6 +94,8 @@ public:
         plannedTrajectoryPublisher = this->create_publisher<nav_msgs::msg::Path>("planned_trajectory", publisher_qos);
         realTrajectoryPublisher = this->create_publisher<nav_msgs::msg::Path>("real_trajectory", publisher_qos);
 
+        statusPublisher = this->create_publisher<std_msgs::msg::String>("status", publisher_qos);
+
         drivingForward.store(true);
         lastDrivingDirection.store(true);
     }
@@ -154,6 +158,8 @@ private:
 
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr plannedTrajectoryPublisher;
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr realTrajectoryPublisher;
+    rclcpp::Publisher<std_msgs::msg::Path>::SharedPtr statusPublisher;
+
 
     void odomCallback(const nav_msgs::msg::Odometry& odomIn)
     {
@@ -612,6 +618,18 @@ private:
     {
         auto realPath = getNavPathFromPathSequence(realTrajectory);
         realTrajectoryPublisher->publish(realPath);
+    }
+
+    /**
+     * @brief Publish WILN status
+     *
+     * @param status A String that contains the status
+     */
+    void publishStatus(const std::string& status)
+    {
+        auto statusMsg = std_msgs::msg::String();
+        statusMsg.data = status;
+        statusPublisher->publish(statusMsg);
     }
 
     void loadLTRServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)

--- a/src/wiln_node.cpp
+++ b/src/wiln_node.cpp
@@ -348,6 +348,8 @@ private:
 
         recording = true;
 
+        publishStatus("TEACHING");
+
         auto enableMappingRequest = std::make_shared<std_srvs::srv::Empty::Request>();
         enableMappingClient->async_send_request(enableMappingRequest);
         return;
@@ -393,12 +395,18 @@ private:
         }
 
         recording = false;
+
+        publishStatus("IDLE:STOPPED");
+
         return;
     }
 
     void clearTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
     {
         plannedTrajectory.paths.clear();
+
+        publishStatus("IDLE:CLEARED TRAJECTORY");
+
         return;
     }
 
@@ -417,6 +425,7 @@ private:
         }
 
         playing = false;
+        publishStatus("IDLE:CANCELED TRAJECTORY");
 
         // TODO: validate action call here
         followPathClient->async_cancel_all_goals();
@@ -460,7 +469,8 @@ private:
         //TODO: force save to same working repository as mapper
         using namespace std::chrono_literals;
         auto saveMapRequest = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
-        std::string mapName = req->file_name.data.substr(0, req->file_name.data.rfind('.')) + ".vtk";
+        std::string mapNameStem = req->file_name.data.substr(0, req->file_name.data.rfind('.'));
+        std::string mapName = mapNameStem + ".vtk";
         saveMapRequest->map_file_name.data = mapName;
 //        auto saveMapFuture = saveMapClient->async_send_request(saveMapRequest);
 //        std::shared_ptr<norlab_icp_mapper_ros::srv::SaveMap::Request> request = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
@@ -665,6 +675,8 @@ private:
         }
 
         robotPoseLock.lock();
+
+        publishStatus("REPEATING");
 
         norlab_controllers_msgs::msg::PathSequence trajectory = plannedTrajectory;
 


### PR DESCRIPTION
Publish status messages (with a `std_msgs/msg/String` publisher), as a way to provide info on WILN to other ROS2 nodes and processes

Further improvements could include implementing status messages through an Enum message