### PR TITLE
Added error feedback to service responses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     "srv/LoadMapTraj.srv"
     "srv/PlayLoop.srv"
     "srv/SaveMapTraj.srv"
+    "msg/WilnStatus.msg"
     DEPENDENCIES std_msgs std_srvs
 )
 

--- a/Warthog_TnR_Foxglove.json
+++ b/Warthog_TnR_Foxglove.json
@@ -1,0 +1,256 @@
+{
+  "configById": {
+    "3D!2h4kfix": {
+      "cameraState": {
+        "perspective": true,
+        "distance": 24.554753263072406,
+        "phi": 42.643448819522874,
+        "thetaOffset": 82.95302162459139,
+        "targetOffset": [
+          1.7901116780039255,
+          -2.901821398961906,
+          -5.659478404389994e-17
+        ],
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-none",
+      "scene": {
+        "transforms": {
+          "showLabel": false,
+          "lineWidth": 0,
+          "axisScale": 0
+        },
+        "enableStats": false
+      },
+      "transforms": {},
+      "topics": {
+        "/planned_trajectory_test": {
+          "visible": true
+        },
+        "/real_trajectory_test": {
+          "visible": true
+        },
+        "/ref_path": {
+          "visible": false
+        },
+        "/target_path": {
+          "visible": false
+        },
+        "/optimal_path": {
+          "visible": false
+        },
+        "/rslidar32_points": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo"
+        },
+        "/map": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo"
+        },
+        "/lslidar_point_cloud_deskewed": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo"
+        },
+        "/robot_description": {
+          "visible": false
+        },
+        "/real_trajectory_test1": {
+          "visible": false
+        }
+      },
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "imageMode": {}
+    },
+    "map!3a986e1": {
+      "customTileUrl": "",
+      "disabledTopics": [
+        "/LocationFix",
+        "/fix",
+        "/geographic_path_end",
+        "/geographic_path_start",
+        "/geographic_robot_path"
+      ],
+      "followTopic": "",
+      "layer": "satellite",
+      "topicColors": {},
+      "maxNativeZoom": 18,
+      "center": {
+        "lat": 46.77829363153993,
+        "lon": -71.27481732577222
+      },
+      "zoomLevel": 17
+    },
+    "Tab!2l8wzyp": {
+      "activeTabIdx": 0,
+      "tabs": [
+        {
+          "title": "3D",
+          "layout": "3D!2h4kfix"
+        },
+        {
+          "title": "Satellite",
+          "layout": "map!3a986e1"
+        }
+      ]
+    },
+    "CallService!ykcnio": {
+      "requestPayload": "{}",
+      "layout": "vertical",
+      "timeoutSeconds": 10,
+      "foxglovePanelTitle": "Start recording",
+      "buttonColor": "#0b9000",
+      "serviceName": "/start_recording",
+      "editingMode": false,
+      "buttonText": "Start recording"
+    },
+    "CallService!1juomu4": {
+      "requestPayload": "{}",
+      "layout": "horizontal",
+      "timeoutSeconds": 10,
+      "foxglovePanelTitle": "Play trajectory",
+      "buttonColor": "#0b9000",
+      "serviceName": "/play_line",
+      "editingMode": false,
+      "buttonText": "Play trajectory once"
+    },
+    "CallService!39pxkwk": {
+      "requestPayload": "{}",
+      "layout": "vertical",
+      "timeoutSeconds": 10,
+      "foxglovePanelTitle": "stop recording",
+      "buttonColor": "#aa0000",
+      "serviceName": "/stop_recording",
+      "editingMode": false,
+      "buttonText": "Stop recording"
+    },
+    "CallService!45oax4p": {
+      "requestPayload": "{\n  \"nb_loops\": 3\n}",
+      "layout": "vertical",
+      "timeoutSeconds": 10,
+      "foxglovePanelTitle": "Play loop trajectory",
+      "buttonColor": "#1700ab",
+      "serviceName": "/play_loop",
+      "editingMode": true,
+      "buttonText": "Play loop trajectory"
+    },
+    "CallService!uz1d3a": {
+      "requestPayload": "{}",
+      "layout": "vertical",
+      "timeoutSeconds": 10,
+      "foxglovePanelTitle": "Play loop trajectory",
+      "buttonColor": "#d09c1f",
+      "serviceName": "/cancel_trajectory",
+      "editingMode": false,
+      "buttonText": "Cancel trajectory"
+    },
+    "CallService!351yhg3": {
+      "requestPayload": "{}",
+      "layout": "horizontal",
+      "timeoutSeconds": 10,
+      "foxglovePanelTitle": "Clear trajectory",
+      "buttonColor": "#aa0000",
+      "serviceName": "/clear_trajectory",
+      "editingMode": false,
+      "buttonText": "Clear trajectory"
+    },
+    "Indicator!7lb452": {
+      "path": "/wiln/status.ok",
+      "style": "background",
+      "fallbackColor": "#ff0000",
+      "fallbackLabel": "Error",
+      "rules": [
+        {
+          "operator": "=",
+          "rawValue": "true",
+          "color": "#68e24a",
+          "label": "Ok"
+        }
+      ]
+    },
+    "RawMessages!4gsut6l": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "diffTopicPath": "",
+      "showFullMessageForDiff": false,
+      "topicPath": "/wiln/status.message",
+      "fontSize": 24
+    }
+  },
+  "globalVariables": {
+    "": "\"\""
+  },
+  "userNodes": {
+    "88743478-bc6c-4c28-bec7-5feaa4f5a52d": {
+      "sourceCode": "// The ./types module provides helper types for your Input events and messages.\nimport { Input, Message } from \"./types\";\n\n\n// Your script can output well-known message types, any of your custom message types, or\n// complete custom message types.\n//\n// Use `Message` to access types from the schemas defined in your data source:\n// type Twist = Message<\"geometry_msgs/Twist\">;\n//\n// Import from the @foxglove/schemas package to use foxglove schema types:\n// import { Pose, LocationFix } from \"@foxglove/schemas\";\n//\n// Conventionally, it's common to make a _type alias_ for your script's output type\n// and use that type name as the return type for your script function.\n// Here we've called the type `Output` but you can pick any type name.\ntype Output = {\n  hello: string;\n};\n\n// These are the topics your script \"subscribes\" to. Studio will invoke your script function\n// when any message is received on one of these topics.\nexport const inputs = [\"/input/topic\"];\n\n// Any output your script produces is \"published\" to this topic. Published messages are only visible within Studio, not to your original data source.\nexport const output = \"/studio_script/output_topic\";\n\n// This function is called with messages from your input topics.\n// The first argument is an event with the topic, receive time, and message.\n// Use the `Input<...>` helper to get the correct event type for your input topic messages.\nexport default function script(event: Input<\"/input/topic\">): Output {\n  return {\n    hello: \"world!\",\n  };\n};",
+      "name": "88743478"
+    }
+  },
+  "playbackConfig": {
+    "speed": 1
+  },
+  "layout": {
+    "first": {
+      "first": {
+        "first": {
+          "first": "Tab!2l8wzyp",
+          "second": {
+            "first": "CallService!ykcnio",
+            "second": "CallService!1juomu4",
+            "direction": "column"
+          },
+          "direction": "row",
+          "splitPercentage": 88.77441504268918
+        },
+        "second": {
+          "first": "CallService!39pxkwk",
+          "second": "CallService!45oax4p",
+          "direction": "column"
+        },
+        "direction": "row",
+        "splitPercentage": 86.3013698630137
+      },
+      "second": {
+        "first": "CallService!uz1d3a",
+        "second": "CallService!351yhg3",
+        "direction": "column"
+      },
+      "direction": "row",
+      "splitPercentage": 92.52217997465145
+    },
+    "second": {
+      "first": "Indicator!7lb452",
+      "second": "RawMessages!4gsut6l",
+      "direction": "row"
+    },
+    "direction": "column",
+    "splitPercentage": 87.78004073319755
+  }
+}

--- a/msg/WilnStatus.msg
+++ b/msg/WilnStatus.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+bool ok
+string message

--- a/src/wiln_node.cpp
+++ b/src/wiln_node.cpp
@@ -1,92 +1,76 @@
-#include <rclcpp/rclcpp.hpp>
-#include <fstream>
-#include <mutex>
-#include <std_srvs/srv/empty.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <tf2/LinearMath/Quaternion.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-#include <wiln/srv/save_map_traj.hpp>
-#include <wiln/srv/load_map_traj.hpp>
-#include <wiln/srv/play_loop.hpp>
-#include <norlab_icp_mapper_ros/srv/save_map.hpp>
-#include <norlab_icp_mapper_ros/srv/load_map.hpp>
-#include <service_caller/ServiceCaller.hpp>
-
+#include <algorithm>
+#include <atomic>
+#include <fstream>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <mutex>
 #include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
-
+#include <norlab_controllers_msgs/action/follow_path.hpp>
 #include <norlab_controllers_msgs/msg/directional_path.hpp>
 #include <norlab_controllers_msgs/msg/path_sequence.hpp>
+#include <norlab_icp_mapper_ros/srv/load_map.hpp>
+#include <norlab_icp_mapper_ros/srv/save_map.hpp>
+#include <rclcpp/future_return_code.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
-#include <norlab_controllers_msgs/action/follow_path.hpp>
+#include <rclcpp_action/server.hpp>
+#include <service_caller/ServiceCaller.hpp>
+#include <std_srvs/srv/trigger.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <wiln/srv/load_map_traj.hpp>
+#include <wiln/srv/play_loop.hpp>
+#include <wiln/srv/save_map_traj.hpp>
 
 tf2::Quaternion HALF_TURN_ROTATION(0.0, 0.0, 1.0, 0.0);
 
-class WilnNode : public rclcpp::Node
-{
-public:
-    WilnNode():
-            Node("wiln_node")
-    {
+class WilnNode : public rclcpp::Node {
+   public:
+    WilnNode() : Node("wiln_node") {
         using FollowPath = norlab_controllers_msgs::action::FollowPath;
 
         // TODO: Create service clients to call enable_mapping, disable_mapping, save_map and load_map
 
-        startRecordingService = this->create_service<std_srvs::srv::Empty>("start_recording",
-                                                                           std::bind(&WilnNode::startRecordingServiceCallback, this, std::placeholders::_1,
-                                                                                     std::placeholders::_2));
-        stopRecordingService = this->create_service<std_srvs::srv::Empty>("stop_recording",
-                                                                          std::bind(&WilnNode::stopRecordingServiceCallback, this, std::placeholders::_1,
-                                                                                    std::placeholders::_2));
-        saveMapTrajService = this->create_service<wiln::srv::SaveMapTraj>("save_map_traj",
-                                                                          std::bind(&WilnNode::saveLTRServiceCallback, this, std::placeholders::_1,
-                                                                                    std::placeholders::_2));
-        loadMapTrajService = this->create_service<wiln::srv::LoadMapTraj>("load_map_traj",
-                                                                          std::bind(&WilnNode::loadLTRServiceCallback, this, std::placeholders::_1,
-                                                                                    std::placeholders::_2));
-        loadMapTrajFromEndService = this->create_service<wiln::srv::LoadMapTraj>("load_map_traj_from_end",
-                                                                                 std::bind(&WilnNode::loadLTRFromEndServiceCallback, this, std::placeholders::_1,
-                                                                                           std::placeholders::_2));
-        playLoopService = this->create_service<wiln::srv::PlayLoop>("play_loop",
-                                                                    std::bind(&WilnNode::playLoopTrajectoryServiceCallback, this, std::placeholders::_1,
-                                                                              std::placeholders::_2));
-        playLineService = this->create_service<std_srvs::srv::Empty>("play_line",
-                                                                     std::bind(&WilnNode::playLineTrajectoryServiceCallback, this, std::placeholders::_1,
-                                                                               std::placeholders::_2));
-        cancelTrajectoryService = this->create_service<std_srvs::srv::Empty>("cancel_trajectory",
-                                                                             std::bind(&WilnNode::cancelTrajectoryServiceCallback, this, std::placeholders::_1,
-                                                                                       std::placeholders::_2));
-        smoothTrajectoryService = this->create_service<std_srvs::srv::Empty>("smooth_trajectory",
-                                                                             std::bind(&WilnNode::smoothTrajectoryServiceCallback, this, std::placeholders::_1,
-                                                                                       std::placeholders::_2));
-        clearTrajectoryService = this->create_service<std_srvs::srv::Empty>("clear_trajectory",
-                                                                            std::bind(&WilnNode::clearTrajectoryServiceCallback, this, std::placeholders::_1,
-                                                                                      std::placeholders::_2));
+        startRecordingService = this->create_service<std_srvs::srv::Trigger>(
+            "start_recording", std::bind(&WilnNode::startRecordingServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        stopRecordingService = this->create_service<std_srvs::srv::Trigger>(
+            "stop_recording", std::bind(&WilnNode::stopRecordingServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        saveMapTrajService = this->create_service<wiln::srv::SaveMapTraj>(
+            "save_map_traj", std::bind(&WilnNode::saveLTRServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        loadMapTrajService = this->create_service<wiln::srv::LoadMapTraj>(
+            "load_map_traj", std::bind(&WilnNode::loadLTRServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        loadMapTrajFromEndService = this->create_service<wiln::srv::LoadMapTraj>(
+            "load_map_traj_from_end", std::bind(&WilnNode::loadLTRFromEndServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        playLoopService = this->create_service<wiln::srv::PlayLoop>(
+            "play_loop", std::bind(&WilnNode::playLoopTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        playLineService = this->create_service<std_srvs::srv::Trigger>(
+            "play_line", std::bind(&WilnNode::playLineTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        cancelTrajectoryService = this->create_service<std_srvs::srv::Trigger>(
+            "cancel_trajectory", std::bind(&WilnNode::cancelTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        smoothTrajectoryService = this->create_service<std_srvs::srv::Trigger>(
+            "smooth_trajectory", std::bind(&WilnNode::smoothTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        clearTrajectoryService = this->create_service<std_srvs::srv::Trigger>(
+            "clear_trajectory", std::bind(&WilnNode::clearTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
 
-        enableMappingClient = this->create_client<std_srvs::srv::Empty>("enable_mapping");
-        disableMappingClient = this->create_client<std_srvs::srv::Empty>("disable_mapping");
+        enableMappingClient = this->create_client<std_srvs::srv::Trigger>("enable_mapping");
+        disableMappingClient = this->create_client<std_srvs::srv::Trigger>("disable_mapping");
         saveMapClient = this->create_client<norlab_icp_mapper_ros::srv::SaveMap>("save_map");
         loadMapClient = this->create_client<norlab_icp_mapper_ros::srv::LoadMap>("load_map");
 
         followPathClient = rclcpp_action::create_client<norlab_controllers_msgs::action::FollowPath>(this, "follow_path");
 
-        odomSubscription = this->create_subscription<nav_msgs::msg::Odometry>("odom_in", 1000,
-                                                                              std::bind(&WilnNode::odomCallback, this,
-                                                                                        std::placeholders::_1));
-        commandedVelocitySubscription = this->create_subscription<geometry_msgs::msg::Twist>("cmd_vel_in", 1000,
-                                                                                             std::bind(&WilnNode::commandVelocityCallback, this,
-                                                                                                       std::placeholders::_1));
-        plannedTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>("pose_in", 1000,
-                                                                                                   std::bind(&WilnNode::plannedTrajectoryCallback, this,
-                                                                                                             std::placeholders::_1));
-        realTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>("pose_in", 1000,
-                                                                                                std::bind(&WilnNode::realTrajectoryCallback, this,
-                                                                                                          std::placeholders::_1));
-//        trajectoryResultSubscription = this->create_subscription<norlab_controllers_msgs::action::FollowPath::Result>("follow_path/result", 1000,
-//                                                                                                std::bind(&WilnNode::trajectoryResultCallback, this,
-//                                                                                                          std::placeholders::_1));
+        odomSubscription = this->create_subscription<nav_msgs::msg::Odometry>("odom_in", 1000, std::bind(&WilnNode::odomCallback, this, std::placeholders::_1));
+        commandedVelocitySubscription = this->create_subscription<geometry_msgs::msg::Twist>(
+            "cmd_vel_in", 1000, std::bind(&WilnNode::commandVelocityCallback, this, std::placeholders::_1));
+        plannedTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+            "pose_in", 1000, std::bind(&WilnNode::plannedTrajectoryCallback, this, std::placeholders::_1));
+        realTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+            "pose_in", 1000, std::bind(&WilnNode::realTrajectoryCallback, this, std::placeholders::_1));
+        //        trajectoryResultSubscription = this->create_subscription<norlab_controllers_msgs::action::FollowPath::Result>("follow_path/result", 1000,
+        //                                                                                                std::bind(&WilnNode::trajectoryResultCallback, this,
+        //                                                                                                          std::placeholders::_1));
         auto publisher_qos = rclcpp::QoS(10);
         publisher_qos.transient_local();
         plannedTrajectoryPublisher = this->create_publisher<nav_msgs::msg::Path>("planned_trajectory", publisher_qos);
@@ -96,7 +80,7 @@ public:
         lastDrivingDirection.store(true);
     }
 
-private:
+   private:
     bool playing;
     bool recording;
     std::atomic_bool drivingForward;
@@ -105,24 +89,24 @@ private:
     geometry_msgs::msg::Pose robotPose;
     std::mutex robotPoseLock;
 
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr startRecordingService;
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr stopRecordingService;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr startRecordingService;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stopRecordingService;
     rclcpp::Service<wiln::srv::SaveMapTraj>::SharedPtr saveMapTrajService;
     rclcpp::Service<wiln::srv::LoadMapTraj>::SharedPtr loadMapTrajService;
     rclcpp::Service<wiln::srv::LoadMapTraj>::SharedPtr loadMapTrajFromEndService;
     rclcpp::Service<wiln::srv::PlayLoop>::SharedPtr playLoopService;
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr playLineService;
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr cancelTrajectoryService;
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr smoothTrajectoryService;
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr clearTrajectoryService;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr playLineService;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr cancelTrajectoryService;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr smoothTrajectoryService;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr clearTrajectoryService;
 
-    rclcpp::Client<std_srvs::srv::Empty>::SharedPtr enableMappingClient;
-    rclcpp::Client<std_srvs::srv::Empty>::SharedPtr disableMappingClient;
+    rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr enableMappingClient;
+    rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr disableMappingClient;
     rclcpp::Client<norlab_icp_mapper_ros::srv::SaveMap>::SharedPtr saveMapClient;
     rclcpp::Client<norlab_icp_mapper_ros::srv::LoadMap>::SharedPtr loadMapClient;
     std::atomic_bool lastDrivingDirection;
 
-    const int FRAME_ID_START_POSITION = 11; // length of string : "frame_id : "
+    const int FRAME_ID_START_POSITION = 11;  // length of string : "frame_id : "
 
     const std::string TRAJECTORY_DELIMITER = "#############################";
     float delayBetweenWaypoints;
@@ -131,17 +115,17 @@ private:
     int lowPassFilterWindowSize;
 
     //    const std::map<int8_t, std::string> FOLLOW_PATH_RESULTS = {
-//            { 0u, "RESULT_STATUS_STOPPED_BY_SUPERVISOR" },
-//            { 1u, "RESULT_STATUS_UNKNOWN" },
-//            { 2u, "RESULT_STATUS_OBSTACLE" },
-//            { 3u, "RESULT_STATUS_SUCCESS" },
-//            { 4u, "RESULT_STATUS_ABORTED" },
-//            { 5u, "RESULT_STATUS_INTERNAL_ERROR" },
-//            { 6u, "RESULT_STATUS_SLAM_FAIL" },
-//            { 7u, "RESULT_STATUS_TF_FAIL" },
-//            { 8u, "RESULT_STATUS_PATH_LOST" },
-//            { 9u, "RESULT_STATUS_TIMEOUT" },
-//    };
+    //            { 0u, "RESULT_STATUS_STOPPED_BY_SUPERVISOR" },
+    //            { 1u, "RESULT_STATUS_UNKNOWN" },
+    //            { 2u, "RESULT_STATUS_OBSTACLE" },
+    //            { 3u, "RESULT_STATUS_SUCCESS" },
+    //            { 4u, "RESULT_STATUS_ABORTED" },
+    //            { 5u, "RESULT_STATUS_INTERNAL_ERROR" },
+    //            { 6u, "RESULT_STATUS_SLAM_FAIL" },
+    //            { 7u, "RESULT_STATUS_TF_FAIL" },
+    //            { 8u, "RESULT_STATUS_PATH_LOST" },
+    //            { 9u, "RESULT_STATUS_TIMEOUT" },
+    //    };
 
     rclcpp_action::Client<norlab_controllers_msgs::action::FollowPath>::SharedPtr followPathClient;
 
@@ -149,46 +133,34 @@ private:
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr commandedVelocitySubscription;
     rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr plannedTrajectorySubscription;
     rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr realTrajectorySubscription;
-//    rclcpp::Subscription<norlab_controllers_msgs::action::FollowPath::Result>::SharedPtr trajectoryResultSubscription;
-
+    //    rclcpp::Subscription<norlab_controllers_msgs::action::FollowPath::Result>::SharedPtr trajectoryResultSubscription;
 
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr plannedTrajectoryPublisher;
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr realTrajectoryPublisher;
 
-    void odomCallback(const nav_msgs::msg::Odometry& odomIn)
-    {
+    void odomCallback(const nav_msgs::msg::Odometry& odomIn) {
         robotPoseLock.lock();
         robotPose = odomIn.pose.pose;
         robotPoseLock.unlock();
     }
 
-    void commandVelocityCallback(const geometry_msgs::msg::Twist& commandedVelocity)
-    {
-        drivingForward.store(commandedVelocity.linear.x >= 0.0);
-    }
+    void commandVelocityCallback(const geometry_msgs::msg::Twist& commandedVelocity) { drivingForward.store(commandedVelocity.linear.x >= 0.0); }
 
-    float computeAngleBetweenPoses(const geometry_msgs::msg::PoseStamped& firstPose, const geometry_msgs::msg::PoseStamped& secondPose)
-    {
+    float computeAngleBetweenPoses(const geometry_msgs::msg::PoseStamped& firstPose, const geometry_msgs::msg::PoseStamped& secondPose) {
         float firstPoseAngle = extractYawFromQuaternion(firstPose.pose.orientation);
         float secondPoseAngle = extractYawFromQuaternion(secondPose.pose.orientation);
         float pathAngle = secondPoseAngle - firstPoseAngle;
-        if(pathAngle > M_PI)
-        {
+        if (pathAngle > M_PI) {
             pathAngle -= 2.0 * M_PI;
-        }
-        else if(pathAngle < -M_PI)
-        {
+        } else if (pathAngle < -M_PI) {
             pathAngle += 2 * M_PI;
         }
         return pathAngle;
     }
 
-    void plannedTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped)
-    {
-        if(recording)
-        {
-            if(plannedTrajectory.paths.empty())
-            {
+    void plannedTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped) {
+        if (recording) {
+            if (plannedTrajectory.paths.empty()) {
                 plannedTrajectory.header.frame_id = poseStamped.header.frame_id;
                 plannedTrajectory.header.stamp = this->now();
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
@@ -198,9 +170,7 @@ private:
                 directionalPath.poses.push_back(poseStamped);
                 plannedTrajectory.paths.push_back(directionalPath);
                 publishPlannedTrajectory();
-            }
-            else if(std::fabs(computeAngleBetweenPoses(plannedTrajectory.paths.back().poses.back(), poseStamped)) > 0.5)
-            {
+            } else if (std::fabs(computeAngleBetweenPoses(plannedTrajectory.paths.back().poses.back(), poseStamped)) > 0.5) {
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                 directionalPath.header.frame_id = poseStamped.header.frame_id;
                 directionalPath.header.stamp = this->now();
@@ -210,9 +180,7 @@ private:
                 directionalPath.poses.push_back(rotatedPose);
                 plannedTrajectory.paths.push_back(directionalPath);
                 publishPlannedTrajectory();
-            }
-            else if(lastDrivingDirection.load() != drivingForward.load())
-            {
+            } else if (lastDrivingDirection.load() != drivingForward.load()) {
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                 directionalPath.header.frame_id = poseStamped.header.frame_id;
                 directionalPath.header.stamp = this->now();
@@ -220,15 +188,12 @@ private:
                 directionalPath.poses.push_back(poseStamped);
                 plannedTrajectory.paths.push_back(directionalPath);
                 publishPlannedTrajectory();
-            }
-            else
-            {
+            } else {
                 geometry_msgs::msg::PoseStamped lastPose = plannedTrajectory.paths.back().poses.back();
                 double distance = std::sqrt(std::pow(poseStamped.pose.position.x - lastPose.pose.position.x, 2) +
                                             std::pow(poseStamped.pose.position.y - lastPose.pose.position.y, 2) +
                                             std::pow(poseStamped.pose.position.z - lastPose.pose.position.z, 2));
-                if(distance >= 0.05)
-                {
+                if (distance >= 0.05) {
                     plannedTrajectory.paths.back().poses.push_back(poseStamped);
                     publishPlannedTrajectory();
                 }
@@ -237,12 +202,9 @@ private:
         }
     }
 
-    void realTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped)
-    {
-        if(playing)
-        {
-            if(realTrajectory.paths.empty())
-            {
+    void realTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped) {
+        if (playing) {
+            if (realTrajectory.paths.empty()) {
                 realTrajectory.header.frame_id = poseStamped.header.frame_id;
                 realTrajectory.header.stamp = this->now();
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
@@ -253,20 +215,19 @@ private:
                 realTrajectory.paths.push_back(directionalPath);
                 publishRealTrajectory();
             }
-//            else if(std::fabs(computeAngleBetweenPoses(realTrajectory.paths.back().poses.back(), poseStamped)) > 0.5)
-//            {
-//                norlab_controllers_msgs::msg::DirectionalPath directionalPath;
-//                directionalPath.header.frame_id = poseStamped.header.frame_id;
-//                directionalPath.header.stamp = this->now();
-//                directionalPath.forward = drivingForward.load();
-//                geometry_msgs::msg::PoseStamped rotatedPose = poseStamped;
-//                rotatedPose.pose.position = realTrajectory.paths.back().poses.back().pose.position;
-//                directionalPath.poses.push_back(rotatedPose);
-//                realTrajectory.paths.push_back(directionalPath);
-//                publishRealTrajectory();
-//            }
-            else if(lastDrivingDirection.load() != drivingForward.load())
-            {
+            //            else if(std::fabs(computeAngleBetweenPoses(realTrajectory.paths.back().poses.back(), poseStamped)) > 0.5)
+            //            {
+            //                norlab_controllers_msgs::msg::DirectionalPath directionalPath;
+            //                directionalPath.header.frame_id = poseStamped.header.frame_id;
+            //                directionalPath.header.stamp = this->now();
+            //                directionalPath.forward = drivingForward.load();
+            //                geometry_msgs::msg::PoseStamped rotatedPose = poseStamped;
+            //                rotatedPose.pose.position = realTrajectory.paths.back().poses.back().pose.position;
+            //                directionalPath.poses.push_back(rotatedPose);
+            //                realTrajectory.paths.push_back(directionalPath);
+            //                publishRealTrajectory();
+            //            }
+            else if (lastDrivingDirection.load() != drivingForward.load()) {
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                 directionalPath.header.frame_id = poseStamped.header.frame_id;
                 directionalPath.header.stamp = this->now();
@@ -274,15 +235,12 @@ private:
                 directionalPath.poses.push_back(poseStamped);
                 realTrajectory.paths.push_back(directionalPath);
                 publishRealTrajectory();
-            }
-            else
-            {
+            } else {
                 geometry_msgs::msg::PoseStamped lastPose = realTrajectory.paths.back().poses.back();
                 double distance = std::sqrt(std::pow(poseStamped.pose.position.x - lastPose.pose.position.x, 2) +
                                             std::pow(poseStamped.pose.position.y - lastPose.pose.position.y, 2) +
                                             std::pow(poseStamped.pose.position.z - lastPose.pose.position.z, 2));
-                if(distance >= 0.05)
-                {
+                if (distance >= 0.05) {
                     realTrajectory.paths.back().poses.push_back(poseStamped);
                     publishRealTrajectory();
                 }
@@ -291,75 +249,65 @@ private:
         }
     }
 
-    void goalResponseCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::SharedPtr& trajectoryGoalHandle)
-    {
-        if(!trajectoryGoalHandle)
-        {
+    void goalResponseCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::SharedPtr& trajectoryGoalHandle) {
+        if (!trajectoryGoalHandle) {
             RCLCPP_ERROR(this->get_logger(), "Goal was rejected by server");
-        }
-        else
-        {
+        } else {
             RCLCPP_INFO(this->get_logger(), "Goal accepted by server, waiting for result");
         }
     }
 
     void trajectoryFeedbackCallback(rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::SharedPtr,
-                                    const std::shared_ptr<const norlab_controllers_msgs::action::FollowPath::Feedback> feedback)
-    {
-        //TODO: program feedback callback
+                                    const std::shared_ptr<const norlab_controllers_msgs::action::FollowPath::Feedback> feedback) {
+        // TODO: program feedback callback
         return;
     }
 
-    void trajectoryResultCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::WrappedResult& trajectory_result)
-    {
+    void trajectoryResultCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::WrappedResult& trajectory_result) {
         playing = false;
 
         RCLCPP_WARN(this->get_logger(), "i got in trajectory_result_callback");
 
-        if(trajectory_result.code == rclcpp_action::ResultCode::SUCCEEDED)
-        {
+        if (trajectory_result.code == rclcpp_action::ResultCode::SUCCEEDED) {
             RCLCPP_WARN(this->get_logger(), "Successfully reached goal!");
-        }
-        else
-        {
+        } else {
             RCLCPP_WARN_STREAM(this->get_logger(), "Trajectory goal was not reached.");
         }
     }
 
-    void startRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
-    {
-        if(recording)
-        {
-            RCLCPP_WARN(this->get_logger(), "Trajectory is already being recorded.");
+    void startRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
+        if (recording) {
+            res->message = "Trajectory is already being recorded.";
+            res->success = false;
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if(playing)
-        {
-            RCLCPP_WARN(this->get_logger(), "Cannot start recording, trajectory is currently being played.");
+        if (playing) {
+            res->message = "Cannot start recording, trajectory is currently being played.";
+            res->success = false;
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
+        res->message = "Recording trajectory.";
+        res->success = true;
         recording = true;
 
-        auto enableMappingRequest = std::make_shared<std_srvs::srv::Empty::Request>();
+        auto enableMappingRequest = std::make_shared<std_srvs::srv::Trigger::Request>();
         enableMappingClient->async_send_request(enableMappingRequest);
         return;
     }
 
-    norlab_controllers_msgs::msg::PathSequence smoothTrajectoryLowPass(const norlab_controllers_msgs::msg::PathSequence& roughTrajectory)
-    {
+    norlab_controllers_msgs::msg::PathSequence smoothTrajectoryLowPass(const norlab_controllers_msgs::msg::PathSequence& roughTrajectory) {
         norlab_controllers_msgs::msg::PathSequence smoothTrajectory(roughTrajectory);
 
-        for(int i = 0; i < roughTrajectory.paths.size(); ++i)
-        {
-            for(int j = lowPassFilterWindowSize; j < roughTrajectory.paths[i].poses.size() - lowPassFilterWindowSize; ++j)
-            {
+        for (int i = 0; i < roughTrajectory.paths.size(); ++i) {
+            for (int j = lowPassFilterWindowSize; j < roughTrajectory.paths[i].poses.size() - lowPassFilterWindowSize; ++j) {
                 double windowNeighborSumX = 0;
                 double windowNeighborSumY = 0;
                 double windowNeighborSumZ = 0;
-                for(int k = j - lowPassFilterWindowSize; k < j + lowPassFilterWindowSize + 1; ++k)
-                {
+                for (int k = j - lowPassFilterWindowSize; k < j + lowPassFilterWindowSize + 1; ++k) {
                     windowNeighborSumX += roughTrajectory.paths[i].poses[k].pose.position.x;
                     windowNeighborSumY += roughTrajectory.paths[i].poses[k].pose.position.y;
                     windowNeighborSumZ += roughTrajectory.paths[i].poses[k].pose.position.z;
@@ -369,8 +317,7 @@ private:
                 smoothTrajectory.paths[i].poses[j].pose.position.z = windowNeighborSumZ / ((2 * lowPassFilterWindowSize) + 1);
             }
         }
-        for(int i = 0; i < lowPassFilterWindowSize; ++i)
-        {
+        for (int i = 0; i < lowPassFilterWindowSize; ++i) {
             smoothTrajectory.paths.front().poses.erase(smoothTrajectory.paths.front().poses.begin());
             smoothTrajectory.paths.back().poses.erase(smoothTrajectory.paths.back().poses.end() - 1);
         }
@@ -378,68 +325,79 @@ private:
         return smoothTrajectory;
     }
 
-    void stopRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
-    {
-        if(!recording)
-        {
-            RCLCPP_WARN(this->get_logger(), "Trajectory is already not being recorded.");
+    void stopRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
+        if (!recording) {
+            res->message = "Trajectory is already not being recorded.";
+            res->success = false;
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
+        res->message = "Stopped recording trajectory.";
+        res->success = true;
         recording = false;
         return;
     }
 
-    void clearTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
-    {
+    void clearTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
         plannedTrajectory.paths.clear();
+        res->message = "Cleared planned trajectory.";
+        res->success = true;
         return;
     }
 
-    void smoothTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
-    {
+    void smoothTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
         plannedTrajectory = smoothTrajectoryLowPass(plannedTrajectory);
+        res->message = "Smoothed planned trajectory.";
+        res->success = true;
         return;
     }
 
-    void cancelTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
-    {
-        if(!playing)
-        {
-            RCLCPP_WARN(this->get_logger(), "Cannot cancel trajectory, no trajectory is being played.");
+    void cancelTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
+        if (!playing) {
+            res->message = "Cannot cancel trajectory, no trajectory is being played.";
+            res->success = false;
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        playing = false;
+        auto future = followPathClient->async_cancel_all_goals();
 
-        // TODO: validate action call here
-        followPathClient->async_cancel_all_goals();
+        rclcpp::FutureReturnCode response = rclcpp::spin_until_future_complete(this->get_node_base_interface(), future);
+        if (response == rclcpp::FutureReturnCode::SUCCESS) {
+            auto responseValue = future.get();
+            if (responseValue->return_code == responseValue->ERROR_NONE) {
+                res->message = "Successfully cancelled trajectory.";
+                res->success = true;
+                playing = false;
+                RCLCPP_INFO(this->get_logger(), "%s", res->message.c_str());
+            } else {
+                res->message = "Failed to cancel trajectory.";
+                res->success = false;
+                RCLCPP_ERROR(this->get_logger(), "%s", res->message.c_str());
+            }
+        }
+
         return;
     }
 
-    double computeEuclideanDistanceBetweenPoses(const geometry_msgs::msg::Pose& firstPose, const geometry_msgs::msg::Pose& secondPose)
-    {
-        return sqrt(pow(firstPose.position.x - secondPose.position.x, 2) +
-                    pow(firstPose.position.y - secondPose.position.y, 2) +
+    double computeEuclideanDistanceBetweenPoses(const geometry_msgs::msg::Pose& firstPose, const geometry_msgs::msg::Pose& secondPose) {
+        return sqrt(pow(firstPose.position.x - secondPose.position.x, 2) + pow(firstPose.position.y - secondPose.position.y, 2) +
                     pow(firstPose.position.z - secondPose.position.z, 2));
     }
 
-    double extractYawFromQuaternion(const geometry_msgs::msg::Quaternion& quaternion)
-    {
+    double extractYawFromQuaternion(const geometry_msgs::msg::Quaternion& quaternion) {
         return std::atan2(2.0f * (quaternion.w * quaternion.z + quaternion.x * quaternion.y),
                           quaternion.w * quaternion.w + quaternion.x * quaternion.x - quaternion.y * quaternion.y - quaternion.z * quaternion.z);
     }
 
-    double computeTrajectoryYaw(const norlab_controllers_msgs::msg::PathSequence& trajectory, const geometry_msgs::msg::Pose& pose)
-    {
+    double computeTrajectoryYaw(const norlab_controllers_msgs::msg::PathSequence& trajectory, const geometry_msgs::msg::Pose& pose) {
         double dx = 0;
         double dy = 0;
         int pathIndex = 0;
-        while(std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && pathIndex < trajectory.paths.size())
-        {
+        while (std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && pathIndex < trajectory.paths.size()) {
             int poseIndex = 0;
-            while(std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && poseIndex < trajectory.paths[pathIndex].poses.size())
-            {
+            while (std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && poseIndex < trajectory.paths[pathIndex].poses.size()) {
                 dx = trajectory.paths[pathIndex].poses[poseIndex].pose.position.x - pose.position.x;
                 dy = trajectory.paths[pathIndex].poses[poseIndex].pose.position.y - pose.position.y;
                 ++poseIndex;
@@ -449,15 +407,14 @@ private:
         return std::atan2(dy, dx);
     }
 
-    void saveLTRServiceCallback(const std::shared_ptr<wiln::srv::SaveMapTraj::Request> req, std::shared_ptr<wiln::srv::SaveMapTraj::Response> res)
-    {
-        //TODO: force save to same working repository as mapper
+    void saveLTRServiceCallback(const std::shared_ptr<wiln::srv::SaveMapTraj::Request> req, std::shared_ptr<wiln::srv::SaveMapTraj::Response> res) {
+        // TODO: force save to same working repository as mapper
         using namespace std::chrono_literals;
         auto saveMapRequest = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
         std::string mapName = req->file_name.data.substr(0, req->file_name.data.rfind('.')) + ".vtk";
         saveMapRequest->map_file_name.data = mapName;
-//        auto saveMapFuture = saveMapClient->async_send_request(saveMapRequest);
-//        std::shared_ptr<norlab_icp_mapper_ros::srv::SaveMap::Request> request = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
+        //        auto saveMapFuture = saveMapClient->async_send_request(saveMapRequest);
+        //        std::shared_ptr<norlab_icp_mapper_ros::srv::SaveMap::Request> request = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
         RCLCPP_INFO(this->get_logger(), "calling /save_map");
         norlab_icp_mapper_ros::srv::SaveMap::Response response = rclcpp::call_service<norlab_icp_mapper_ros::srv::SaveMap>("save_map", saveMapRequest);
         RCLCPP_INFO(this->get_logger(), "/save_map done");
@@ -468,30 +425,27 @@ private:
         ltrFile << TRAJECTORY_DELIMITER << std::endl;
         ltrFile << "frame_id : " << plannedTrajectory.paths.front().poses.front().header.frame_id << std::endl;
 
-        for(int i = 0; i < plannedTrajectory.paths.size(); ++i)
-        {
-            for(int j = 0; j < plannedTrajectory.paths[i].poses.size(); ++j)
-            {
-                ltrFile << plannedTrajectory.paths[i].poses[j].pose.position.x << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.position.y << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.position.z << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.orientation.x << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.orientation.y << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.orientation.z << ","
+        for (int i = 0; i < plannedTrajectory.paths.size(); ++i) {
+            for (int j = 0; j < plannedTrajectory.paths[i].poses.size(); ++j) {
+                ltrFile << plannedTrajectory.paths[i].poses[j].pose.position.x << "," << plannedTrajectory.paths[i].poses[j].pose.position.y << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.position.z << "," << plannedTrajectory.paths[i].poses[j].pose.orientation.x << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.orientation.y << "," << plannedTrajectory.paths[i].poses[j].pose.orientation.z << ","
                         << plannedTrajectory.paths[i].poses[j].pose.orientation.w << std::endl;
             }
-            if(i != plannedTrajectory.paths.size() - 1)
-            {
+            if (i != plannedTrajectory.paths.size() - 1) {
                 ltrFile << "changing direction" << std::endl;
             }
         }
 
         ltrFile.close();
-        RCLCPP_INFO(this->get_logger(), "LTR file succesfully saved");
+
+        // TODO : handle errors
+        res->message = "LTR file succesfully saved.";
+        res->success = true;
+        RCLCPP_INFO(this->get_logger(), "%s", res->message.c_str());
     }
 
-    void loadLTR(std::string fileName, bool fromEnd)
-    {
+    void loadLTR(std::string fileName, bool fromEnd) {
         using namespace std::chrono_literals;
         plannedTrajectory.paths.clear();
         std::ofstream mapFile("/tmp/map.vtk");
@@ -499,27 +453,19 @@ private:
         std::string line;
         std::string pathFrameId;
         bool parsingMap = true;
-        while(std::getline(ltrFile, line))
-        {
-            if(parsingMap)
-            {
-                if(line.find(TRAJECTORY_DELIMITER) != std::string::npos)
-                {
+        while (std::getline(ltrFile, line)) {
+            if (parsingMap) {
+                if (line.find(TRAJECTORY_DELIMITER) != std::string::npos) {
                     std::getline(ltrFile, line);
                     pathFrameId = line.substr(FRAME_ID_START_POSITION);
                     plannedTrajectory.header.frame_id = pathFrameId;
                     plannedTrajectory.header.stamp = this->now();
                     parsingMap = false;
-                }
-                else
-                {
+                } else {
                     mapFile << line << std::endl;
                 }
-            }
-            else
-            {
-                if(plannedTrajectory.paths.empty())
-                {
+            } else {
+                if (plannedTrajectory.paths.empty()) {
                     norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                     directionalPath.header.frame_id = pathFrameId;
                     directionalPath.header.stamp = this->now();
@@ -527,8 +473,7 @@ private:
                     plannedTrajectory.paths.push_back(directionalPath);
                 }
 
-                if(line.find("changing direction") != std::string::npos)
-                {
+                if (line.find("changing direction") != std::string::npos) {
                     norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                     directionalPath.header.frame_id = pathFrameId;
                     directionalPath.header.stamp = this->now();
@@ -572,13 +517,10 @@ private:
 
         int pathIndex;
         int poseIndex;
-        if(!fromEnd)
-        {
+        if (!fromEnd) {
             pathIndex = 0;
             poseIndex = 0;
-        }
-        else
-        {
+        } else {
             pathIndex = plannedTrajectory.paths.size() - 1;
             poseIndex = plannedTrajectory.paths[pathIndex].poses.size() - 1;
         }
@@ -592,7 +534,7 @@ private:
         loadMapRequest->pose.orientation.w = plannedTrajectory.paths[pathIndex].poses[poseIndex].pose.orientation.w;
         loadMapClient->async_send_request(loadMapRequest);
 
-//        auto loadMapFuture = loadMapClient->async_send_request(loadMapRequest);
+        //        auto loadMapFuture = loadMapClient->async_send_request(loadMapRequest);
         RCLCPP_INFO(this->get_logger(), "calling /load_map");
         norlab_icp_mapper_ros::srv::LoadMap::Response response = rclcpp::call_service<norlab_icp_mapper_ros::srv::LoadMap>("load_map", loadMapRequest);
         RCLCPP_INFO(this->get_logger(), "/load_map done");
@@ -602,47 +544,53 @@ private:
         publishPlannedTrajectory();
     }
 
-    void publishPlannedTrajectory()
-    {
+    void publishPlannedTrajectory() {
         auto plannedPath = getNavPathFromPathSequence(plannedTrajectory);
         plannedTrajectoryPublisher->publish(plannedPath);
     }
 
-    void publishRealTrajectory()
-    {
+    void publishRealTrajectory() {
         auto realPath = getNavPathFromPathSequence(realTrajectory);
         realTrajectoryPublisher->publish(realPath);
     }
 
-    void loadLTRServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)
-    {
+    void loadLTRServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res) {
         loadLTR(req->file_name.data, false);
+
+        // TODO : handle errors
+        res->message = "Loaded LTR file.";
+        res->success = true;
         return;
     }
 
-    void loadLTRFromEndServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)
-    {
+    void loadLTRFromEndServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res) {
         loadLTR(req->file_name.data, true);
+
+        // TODO : handle errors
+        res->message = "Loaded LTR file.";
+        res->success = true;
         return;
     }
 
-    void playLineTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Empty::Request> req, std::shared_ptr<std_srvs::srv::Empty::Response> res)
-    {
-        if(playing)
-        {
-            RCLCPP_WARN(this->get_logger(), "Trajectory is already being played.");
+    void playLineTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
+        if (playing) {
+            res->success = false;
+            res->message = "Trajectory is already being played.";
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if(recording)
-        {
-            RCLCPP_WARN(this->get_logger(), "Cannot play trajectory while recording.");
+        if (recording) {
+            res->success = false;
+            res->message = "Cannot play trajectory while recording.";
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if(plannedTrajectory.paths.empty() || plannedTrajectory.paths.front().poses.empty())
-        {
-            RCLCPP_WARN(this->get_logger(), "Cannot play an empty trajectory.");
+        if (plannedTrajectory.paths.empty() || plannedTrajectory.paths.front().poses.empty()) {
+            res->success = false;
+            res->message = "Cannot play an empty trajectory.";
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
@@ -653,19 +601,16 @@ private:
         double robotPoseToTrajectoryStartDistance = computeEuclideanDistanceBetweenPoses(robotPose, trajectory.paths.front().poses.front().pose);
         double robotPoseToTrajectoryEndDistance = computeEuclideanDistanceBetweenPoses(robotPose, trajectory.paths.back().poses.back().pose);
 
-        RCLCPP_INFO_STREAM(this->get_logger(), "distance to start "<<robotPoseToTrajectoryStartDistance);
-        RCLCPP_INFO_STREAM(this->get_logger(), "distance to end "<<robotPoseToTrajectoryEndDistance);
+        RCLCPP_INFO_STREAM(this->get_logger(), "distance to start " << robotPoseToTrajectoryStartDistance);
+        RCLCPP_INFO_STREAM(this->get_logger(), "distance to end " << robotPoseToTrajectoryEndDistance);
 
-        if(robotPoseToTrajectoryEndDistance < robotPoseToTrajectoryStartDistance)
-        {
+        if (robotPoseToTrajectoryEndDistance < robotPoseToTrajectoryStartDistance) {
             tf2::Quaternion robotOrientation;
 
             std::reverse(trajectory.paths.begin(), trajectory.paths.end());
-            for(int i = 0; i < trajectory.paths.size(); ++i)
-            {
+            for (int i = 0; i < trajectory.paths.size(); ++i) {
                 std::reverse(trajectory.paths[i].poses.begin(), trajectory.paths[i].poses.end());
-                for(int j = 0; j < trajectory.paths[i].poses.size(); ++j)
-                {
+                for (int j = 0; j < trajectory.paths[i].poses.size(); ++j) {
                     tf2::fromMsg(trajectory.paths[i].poses[j].pose.orientation, robotOrientation);
                     trajectory.paths[i].poses[j].pose.orientation = tf2::toMsg((HALF_TURN_ROTATION * robotOrientation).normalized());
                 }
@@ -675,20 +620,16 @@ private:
         double robotPoseYaw = extractYawFromQuaternion(robotPose.orientation);
         double trajectoryStartYaw = computeTrajectoryYaw(trajectory, robotPose);
         double angleDistance = std::fabs(trajectoryStartYaw - robotPoseYaw);
-        if(angleDistance > M_PI)
-        {
+        if (angleDistance > M_PI) {
             angleDistance = (2 * M_PI) - angleDistance;
         }
 
-        if(angleDistance > M_PI_2)
-        {
+        if (angleDistance > M_PI_2) {
             tf2::Quaternion robotOrientation;
 
-            for(int i = 0; i < trajectory.paths.size(); ++i)
-            {
+            for (int i = 0; i < trajectory.paths.size(); ++i) {
                 trajectory.paths[i].forward = !plannedTrajectory.paths[i].forward;
-                for(int j = 0; j < trajectory.paths[i].poses.size(); ++j)
-                {
+                for (int j = 0; j < trajectory.paths[i].poses.size(); ++j) {
                     tf2::fromMsg(trajectory.paths[i].poses[j].pose.orientation, robotOrientation);
                     trajectory.paths[i].poses[j].pose.orientation = tf2::toMsg((HALF_TURN_ROTATION * robotOrientation).normalized());
                 }
@@ -700,73 +641,75 @@ private:
 
         realTrajectory.paths.clear();
 
-        auto disableMappingRequest = std::make_shared<std_srvs::srv::Empty::Request>();
+        auto disableMappingRequest = std::make_shared<std_srvs::srv::Trigger::Request>();
         disableMappingClient->async_send_request(disableMappingRequest);
 
         // TODO: validate action call
         auto goal_msg = norlab_controllers_msgs::action::FollowPath::Goal();
-        goal_msg.follower_options.init_mode.data = 1; // init_mode = 1 : continue
+        goal_msg.follower_options.init_mode.data = 1;  // init_mode = 1 : continue
         goal_msg.follower_options.velocity.data = trajectorySpeed;
         goal_msg.path = trajectory;
         goal_msg.path.header.frame_id = trajectory.paths.front().poses.front().header.frame_id;
         goal_msg.path.header.stamp = this->now();
 
         auto send_goal_options = rclcpp_action::Client<norlab_controllers_msgs::action::FollowPath>::SendGoalOptions();
-        send_goal_options.goal_response_callback =
-                std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
-        send_goal_options.feedback_callback =
-                std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
-        send_goal_options.result_callback =
-                std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
+        send_goal_options.goal_response_callback = std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
+        send_goal_options.feedback_callback = std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
+        send_goal_options.result_callback = std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
         followPathClient->async_send_goal(goal_msg, send_goal_options);
 
+        res->success = true;
+        res->message = "Playing trajectory.";
         return;
     }
 
-    void playLoopTrajectoryServiceCallback(const std::shared_ptr<wiln::srv::PlayLoop::Request> req, std::shared_ptr<wiln::srv::PlayLoop::Response> res)
-    {
-        if(playing)
-        {
-            RCLCPP_WARN(this->get_logger(), "Trajectory is already being played.");
+    void playLoopTrajectoryServiceCallback(const std::shared_ptr<wiln::srv::PlayLoop::Request> req, std::shared_ptr<wiln::srv::PlayLoop::Response> res) {
+        if (playing) {
+            res->success = false;
+            res->message = "Trajectory is already being played.";
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if(recording)
-        {
-            RCLCPP_WARN(this->get_logger(), "Cannot play trajectory while recording.");
+        if (recording) {
+            res->success = false;
+            res->message = "Cannot play trajectory while recording.";
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if(plannedTrajectory.paths.empty())
-        {
-            RCLCPP_WARN(this->get_logger(), "Cannot play an empty trajectory.");
+        if (plannedTrajectory.paths.empty()) {
+            res->success = false;
+            res->message = "Cannot play an empty trajectory.";
+            RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
         norlab_controllers_msgs::msg::PathSequence cutLoopTrajectory = plannedTrajectory;
         int poseIndex = cutLoopTrajectory.paths.back().poses.size() - 1;
-        while(poseIndex >= 1 && computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex - 1].pose, cutLoopTrajectory.paths.front().poses.front().pose) <
-                                computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex].pose, cutLoopTrajectory.paths.front().poses.front().pose))
-        {
+        while (poseIndex >= 1 && computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex - 1].pose,
+                                                                      cutLoopTrajectory.paths.front().poses.front().pose) <
+                                     computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex].pose,
+                                                                          cutLoopTrajectory.paths.front().poses.front().pose)) {
             cutLoopTrajectory.paths.back().poses.erase(cutLoopTrajectory.paths.back().poses.begin() + poseIndex);
             --poseIndex;
         }
         norlab_controllers_msgs::msg::PathSequence firstLoopTrajectory = cutLoopTrajectory;
-        while(firstLoopTrajectory.paths.front().poses.size() > 0 &&
-              computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses.back().pose, firstLoopTrajectory.paths.back().poses.back().pose) < 1.0)
-        {
+        while (firstLoopTrajectory.paths.front().poses.size() > 0 &&
+               computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses.back().pose, firstLoopTrajectory.paths.back().poses.back().pose) <
+                   1.0) {
             firstLoopTrajectory.paths.front().poses.erase(firstLoopTrajectory.paths.back().poses.end() - 1);
         }
         norlab_controllers_msgs::msg::PathSequence lastLoopTrajectory = cutLoopTrajectory;
-        while(lastLoopTrajectory.paths.front().poses.size() > 0 &&
-              computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, lastLoopTrajectory.paths.front().poses.front().pose) < 1.0)
-        {
+        while (lastLoopTrajectory.paths.front().poses.size() > 0 &&
+               computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, lastLoopTrajectory.paths.front().poses.front().pose) <
+                   1.0) {
             lastLoopTrajectory.paths.front().poses.erase(lastLoopTrajectory.paths.front().poses.begin());
         }
         norlab_controllers_msgs::msg::PathSequence middleLoopTrajectory = firstLoopTrajectory;
-        while(middleLoopTrajectory.paths.front().poses.size() > 0 &&
-              computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, middleLoopTrajectory.paths.front().poses.front().pose) < 1.0)
-        {
+        while (middleLoopTrajectory.paths.front().poses.size() > 0 &&
+               computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, middleLoopTrajectory.paths.front().poses.front().pose) <
+                   1.0) {
             middleLoopTrajectory.paths.front().poses.erase(middleLoopTrajectory.paths.front().poses.begin());
         }
 
@@ -774,81 +717,62 @@ private:
 
         realTrajectory.paths.clear();
 
-        auto disableMappingRequest = std::make_shared<std_srvs::srv::Empty::Request>();
+        auto disableMappingRequest = std::make_shared<std_srvs::srv::Trigger::Request>();
         disableMappingClient->async_send_request(disableMappingRequest);
 
         // TODO: validate action call
         auto goal_msg = norlab_controllers_msgs::action::FollowPath::Goal();
-        goal_msg.follower_options.init_mode.data = 1; // init_mode = 1 : continue
+        goal_msg.follower_options.init_mode.data = 1;  // init_mode = 1 : continue
         goal_msg.follower_options.velocity.data = trajectorySpeed;
         goal_msg.path.header.frame_id = plannedTrajectory.paths.front().poses.front().header.frame_id;
         goal_msg.path.header.stamp = this->now();
-        for(int i = 0; i < firstLoopTrajectory.paths.size(); ++i)
-        {
-            if(i != 0 && firstLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward)
-            {
-                for(int j = 0; j < firstLoopTrajectory.paths[i].poses.size(); ++j)
-                {
+        for (int i = 0; i < firstLoopTrajectory.paths.size(); ++i) {
+            if (i != 0 && firstLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward) {
+                for (int j = 0; j < firstLoopTrajectory.paths[i].poses.size(); ++j) {
                     goal_msg.path.paths.back().poses.push_back(firstLoopTrajectory.paths[i].poses[j]);
                 }
-            }
-            else
-            {
+            } else {
                 goal_msg.path.paths.push_back(firstLoopTrajectory.paths[i]);
             }
         }
-        for(int i = 1; i < req->nb_loops.data - 1; ++i)
-        {
-            for(int j = 0; j < middleLoopTrajectory.paths.size(); ++j)
-            {
-                if(middleLoopTrajectory.paths[j].forward == goal_msg.path.paths.back().forward)
-                {
-                    for(int k = 0; k < middleLoopTrajectory.paths[j].poses.size(); ++k)
-                    {
+        for (int i = 1; i < req->nb_loops.data - 1; ++i) {
+            for (int j = 0; j < middleLoopTrajectory.paths.size(); ++j) {
+                if (middleLoopTrajectory.paths[j].forward == goal_msg.path.paths.back().forward) {
+                    for (int k = 0; k < middleLoopTrajectory.paths[j].poses.size(); ++k) {
                         goal_msg.path.paths.back().poses.push_back(middleLoopTrajectory.paths[j].poses[k]);
                     }
-                }
-                else
-                {
+                } else {
                     goal_msg.path.paths.push_back(middleLoopTrajectory.paths[j]);
                 }
             }
         }
 
-        for(int i = 0; i < lastLoopTrajectory.paths.size(); ++i)
-        {
-            if(lastLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward)
-            {
-                for(int j = 0; j < lastLoopTrajectory.paths[i].poses.size(); ++j)
-                {
+        for (int i = 0; i < lastLoopTrajectory.paths.size(); ++i) {
+            if (lastLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward) {
+                for (int j = 0; j < lastLoopTrajectory.paths[i].poses.size(); ++j) {
                     goal_msg.path.paths.back().poses.push_back(lastLoopTrajectory.paths[i].poses[j]);
                 }
-            }
-            else
-            {
+            } else {
                 goal_msg.path.paths.push_back(lastLoopTrajectory.paths[i]);
             }
         }
 
         auto send_goal_options = rclcpp_action::Client<norlab_controllers_msgs::action::FollowPath>::SendGoalOptions();
-        send_goal_options.goal_response_callback =
-                std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
-        send_goal_options.feedback_callback =
-                std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
-        send_goal_options.result_callback =
-                std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
+        send_goal_options.goal_response_callback = std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
+        send_goal_options.feedback_callback = std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
+        send_goal_options.result_callback = std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
         followPathClient->async_send_goal(goal_msg);
+
+        res->success = true;
+        res->message = "Playing loop trajectory.";
         return;
     }
 
-    nav_msgs::msg::Path getNavPathFromPathSequence(const norlab_controllers_msgs::msg::PathSequence& pathSequence)
-    {
+    nav_msgs::msg::Path getNavPathFromPathSequence(const norlab_controllers_msgs::msg::PathSequence& pathSequence) {
         nav_msgs::msg::Path navPath;
         navPath.header = pathSequence.header;
-        for(const auto& path: pathSequence.paths)
-        {
-            for(const geometry_msgs::msg::PoseStamped& poseStamped: path.poses)
-            {
+        for (const auto& path : pathSequence.paths) {
+            for (const geometry_msgs::msg::PoseStamped& poseStamped : path.poses) {
                 navPath.poses.push_back(poseStamped);
             }
         }
@@ -856,10 +780,9 @@ private:
     }
 };
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
     rclcpp::init(argc, argv);
-//    rclcpp::spin(std::make_shared<WilnNode>());
+    //    rclcpp::spin(std::make_shared<WilnNode>());
     rclcpp::executors::MultiThreadedExecutor executor;
     auto wiln_node = std::make_shared<WilnNode>();
     executor.add_node(wiln_node);

--- a/src/wiln_node.cpp
+++ b/src/wiln_node.cpp
@@ -1,58 +1,69 @@
-#include <tf2/LinearMath/Quaternion.h>
-
-#include <algorithm>
-#include <atomic>
-#include <fstream>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/twist.hpp>
-#include <mutex>
-#include <nav_msgs/msg/odometry.hpp>
-#include <nav_msgs/msg/path.hpp>
-#include <norlab_controllers_msgs/action/follow_path.hpp>
-#include <norlab_controllers_msgs/msg/directional_path.hpp>
-#include <norlab_controllers_msgs/msg/path_sequence.hpp>
-#include <norlab_icp_mapper_ros/srv/load_map.hpp>
-#include <norlab_icp_mapper_ros/srv/save_map.hpp>
-#include <rclcpp/future_return_code.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp_action/rclcpp_action.hpp>
-#include <rclcpp_action/server.hpp>
-#include <service_caller/ServiceCaller.hpp>
+#include <fstream>
+#include <mutex>
 #include <std_srvs/srv/trigger.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <wiln/srv/save_map_traj.hpp>
 #include <wiln/srv/load_map_traj.hpp>
 #include <wiln/srv/play_loop.hpp>
-#include <wiln/srv/save_map_traj.hpp>
+#include <norlab_icp_mapper_ros/srv/save_map.hpp>
+#include <norlab_icp_mapper_ros/srv/load_map.hpp>
+#include <service_caller/ServiceCaller.hpp>
+
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+
+#include <norlab_controllers_msgs/msg/directional_path.hpp>
+#include <norlab_controllers_msgs/msg/path_sequence.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <norlab_controllers_msgs/action/follow_path.hpp>
 
 tf2::Quaternion HALF_TURN_ROTATION(0.0, 0.0, 1.0, 0.0);
 
-class WilnNode : public rclcpp::Node {
-   public:
-    WilnNode() : Node("wiln_node") {
+class WilnNode : public rclcpp::Node
+{
+public:
+    WilnNode():
+            Node("wiln_node")
+    {
         using FollowPath = norlab_controllers_msgs::action::FollowPath;
 
         // TODO: Create service clients to call enable_mapping, disable_mapping, save_map and load_map
 
-        startRecordingService = this->create_service<std_srvs::srv::Trigger>(
-            "start_recording", std::bind(&WilnNode::startRecordingServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        stopRecordingService = this->create_service<std_srvs::srv::Trigger>(
-            "stop_recording", std::bind(&WilnNode::stopRecordingServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        saveMapTrajService = this->create_service<wiln::srv::SaveMapTraj>(
-            "save_map_traj", std::bind(&WilnNode::saveLTRServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        loadMapTrajService = this->create_service<wiln::srv::LoadMapTraj>(
-            "load_map_traj", std::bind(&WilnNode::loadLTRServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        loadMapTrajFromEndService = this->create_service<wiln::srv::LoadMapTraj>(
-            "load_map_traj_from_end", std::bind(&WilnNode::loadLTRFromEndServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        playLoopService = this->create_service<wiln::srv::PlayLoop>(
-            "play_loop", std::bind(&WilnNode::playLoopTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        playLineService = this->create_service<std_srvs::srv::Trigger>(
-            "play_line", std::bind(&WilnNode::playLineTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        cancelTrajectoryService = this->create_service<std_srvs::srv::Trigger>(
-            "cancel_trajectory", std::bind(&WilnNode::cancelTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        smoothTrajectoryService = this->create_service<std_srvs::srv::Trigger>(
-            "smooth_trajectory", std::bind(&WilnNode::smoothTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
-        clearTrajectoryService = this->create_service<std_srvs::srv::Trigger>(
-            "clear_trajectory", std::bind(&WilnNode::clearTrajectoryServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+        startRecordingService = this->create_service<std_srvs::srv::Trigger>("start_recording",
+                                                                           std::bind(&WilnNode::startRecordingServiceCallback, this, std::placeholders::_1,
+                                                                                     std::placeholders::_2));
+        stopRecordingService = this->create_service<std_srvs::srv::Trigger>("stop_recording",
+                                                                          std::bind(&WilnNode::stopRecordingServiceCallback, this, std::placeholders::_1,
+                                                                                    std::placeholders::_2));
+        saveMapTrajService = this->create_service<wiln::srv::SaveMapTraj>("save_map_traj",
+                                                                          std::bind(&WilnNode::saveLTRServiceCallback, this, std::placeholders::_1,
+                                                                                    std::placeholders::_2));
+        loadMapTrajService = this->create_service<wiln::srv::LoadMapTraj>("load_map_traj",
+                                                                          std::bind(&WilnNode::loadLTRServiceCallback, this, std::placeholders::_1,
+                                                                                    std::placeholders::_2));
+        loadMapTrajFromEndService = this->create_service<wiln::srv::LoadMapTraj>("load_map_traj_from_end",
+                                                                                 std::bind(&WilnNode::loadLTRFromEndServiceCallback, this, std::placeholders::_1,
+                                                                                           std::placeholders::_2));
+        playLoopService = this->create_service<wiln::srv::PlayLoop>("play_loop",
+                                                                    std::bind(&WilnNode::playLoopTrajectoryServiceCallback, this, std::placeholders::_1,
+                                                                              std::placeholders::_2));
+        playLineService = this->create_service<std_srvs::srv::Trigger>("play_line",
+                                                                     std::bind(&WilnNode::playLineTrajectoryServiceCallback, this, std::placeholders::_1,
+                                                                               std::placeholders::_2));
+        cancelTrajectoryService = this->create_service<std_srvs::srv::Trigger>("cancel_trajectory",
+                                                                             std::bind(&WilnNode::cancelTrajectoryServiceCallback, this, std::placeholders::_1,
+                                                                                       std::placeholders::_2));
+        smoothTrajectoryService = this->create_service<std_srvs::srv::Trigger>("smooth_trajectory",
+                                                                             std::bind(&WilnNode::smoothTrajectoryServiceCallback, this, std::placeholders::_1,
+                                                                                       std::placeholders::_2));
+        clearTrajectoryService = this->create_service<std_srvs::srv::Trigger>("clear_trajectory",
+                                                                            std::bind(&WilnNode::clearTrajectoryServiceCallback, this, std::placeholders::_1,
+                                                                                      std::placeholders::_2));
 
         enableMappingClient = this->create_client<std_srvs::srv::Trigger>("enable_mapping");
         disableMappingClient = this->create_client<std_srvs::srv::Trigger>("disable_mapping");
@@ -61,16 +72,21 @@ class WilnNode : public rclcpp::Node {
 
         followPathClient = rclcpp_action::create_client<norlab_controllers_msgs::action::FollowPath>(this, "follow_path");
 
-        odomSubscription = this->create_subscription<nav_msgs::msg::Odometry>("odom_in", 1000, std::bind(&WilnNode::odomCallback, this, std::placeholders::_1));
-        commandedVelocitySubscription = this->create_subscription<geometry_msgs::msg::Twist>(
-            "cmd_vel_in", 1000, std::bind(&WilnNode::commandVelocityCallback, this, std::placeholders::_1));
-        plannedTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>(
-            "pose_in", 1000, std::bind(&WilnNode::plannedTrajectoryCallback, this, std::placeholders::_1));
-        realTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>(
-            "pose_in", 1000, std::bind(&WilnNode::realTrajectoryCallback, this, std::placeholders::_1));
-        //        trajectoryResultSubscription = this->create_subscription<norlab_controllers_msgs::action::FollowPath::Result>("follow_path/result", 1000,
-        //                                                                                                std::bind(&WilnNode::trajectoryResultCallback, this,
-        //                                                                                                          std::placeholders::_1));
+        odomSubscription = this->create_subscription<nav_msgs::msg::Odometry>("odom_in", 1000,
+                                                                              std::bind(&WilnNode::odomCallback, this,
+                                                                                        std::placeholders::_1));
+        commandedVelocitySubscription = this->create_subscription<geometry_msgs::msg::Twist>("cmd_vel_in", 1000,
+                                                                                             std::bind(&WilnNode::commandVelocityCallback, this,
+                                                                                                       std::placeholders::_1));
+        plannedTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>("pose_in", 1000,
+                                                                                                   std::bind(&WilnNode::plannedTrajectoryCallback, this,
+                                                                                                             std::placeholders::_1));
+        realTrajectorySubscription = this->create_subscription<geometry_msgs::msg::PoseStamped>("pose_in", 1000,
+                                                                                                std::bind(&WilnNode::realTrajectoryCallback, this,
+                                                                                                          std::placeholders::_1));
+//        trajectoryResultSubscription = this->create_subscription<norlab_controllers_msgs::action::FollowPath::Result>("follow_path/result", 1000,
+//                                                                                                std::bind(&WilnNode::trajectoryResultCallback, this,
+//                                                                                                          std::placeholders::_1));
         auto publisher_qos = rclcpp::QoS(10);
         publisher_qos.transient_local();
         plannedTrajectoryPublisher = this->create_publisher<nav_msgs::msg::Path>("planned_trajectory", publisher_qos);
@@ -80,7 +96,7 @@ class WilnNode : public rclcpp::Node {
         lastDrivingDirection.store(true);
     }
 
-   private:
+private:
     bool playing;
     bool recording;
     std::atomic_bool drivingForward;
@@ -106,7 +122,7 @@ class WilnNode : public rclcpp::Node {
     rclcpp::Client<norlab_icp_mapper_ros::srv::LoadMap>::SharedPtr loadMapClient;
     std::atomic_bool lastDrivingDirection;
 
-    const int FRAME_ID_START_POSITION = 11;  // length of string : "frame_id : "
+    const int FRAME_ID_START_POSITION = 11; // length of string : "frame_id : "
 
     const std::string TRAJECTORY_DELIMITER = "#############################";
     float delayBetweenWaypoints;
@@ -115,17 +131,17 @@ class WilnNode : public rclcpp::Node {
     int lowPassFilterWindowSize;
 
     //    const std::map<int8_t, std::string> FOLLOW_PATH_RESULTS = {
-    //            { 0u, "RESULT_STATUS_STOPPED_BY_SUPERVISOR" },
-    //            { 1u, "RESULT_STATUS_UNKNOWN" },
-    //            { 2u, "RESULT_STATUS_OBSTACLE" },
-    //            { 3u, "RESULT_STATUS_SUCCESS" },
-    //            { 4u, "RESULT_STATUS_ABORTED" },
-    //            { 5u, "RESULT_STATUS_INTERNAL_ERROR" },
-    //            { 6u, "RESULT_STATUS_SLAM_FAIL" },
-    //            { 7u, "RESULT_STATUS_TF_FAIL" },
-    //            { 8u, "RESULT_STATUS_PATH_LOST" },
-    //            { 9u, "RESULT_STATUS_TIMEOUT" },
-    //    };
+//            { 0u, "RESULT_STATUS_STOPPED_BY_SUPERVISOR" },
+//            { 1u, "RESULT_STATUS_UNKNOWN" },
+//            { 2u, "RESULT_STATUS_OBSTACLE" },
+//            { 3u, "RESULT_STATUS_SUCCESS" },
+//            { 4u, "RESULT_STATUS_ABORTED" },
+//            { 5u, "RESULT_STATUS_INTERNAL_ERROR" },
+//            { 6u, "RESULT_STATUS_SLAM_FAIL" },
+//            { 7u, "RESULT_STATUS_TF_FAIL" },
+//            { 8u, "RESULT_STATUS_PATH_LOST" },
+//            { 9u, "RESULT_STATUS_TIMEOUT" },
+//    };
 
     rclcpp_action::Client<norlab_controllers_msgs::action::FollowPath>::SharedPtr followPathClient;
 
@@ -133,34 +149,46 @@ class WilnNode : public rclcpp::Node {
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr commandedVelocitySubscription;
     rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr plannedTrajectorySubscription;
     rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr realTrajectorySubscription;
-    //    rclcpp::Subscription<norlab_controllers_msgs::action::FollowPath::Result>::SharedPtr trajectoryResultSubscription;
+//    rclcpp::Subscription<norlab_controllers_msgs::action::FollowPath::Result>::SharedPtr trajectoryResultSubscription;
+
 
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr plannedTrajectoryPublisher;
     rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr realTrajectoryPublisher;
 
-    void odomCallback(const nav_msgs::msg::Odometry& odomIn) {
+    void odomCallback(const nav_msgs::msg::Odometry& odomIn)
+    {
         robotPoseLock.lock();
         robotPose = odomIn.pose.pose;
         robotPoseLock.unlock();
     }
 
-    void commandVelocityCallback(const geometry_msgs::msg::Twist& commandedVelocity) { drivingForward.store(commandedVelocity.linear.x >= 0.0); }
+    void commandVelocityCallback(const geometry_msgs::msg::Twist& commandedVelocity)
+    {
+        drivingForward.store(commandedVelocity.linear.x >= 0.0);
+    }
 
-    float computeAngleBetweenPoses(const geometry_msgs::msg::PoseStamped& firstPose, const geometry_msgs::msg::PoseStamped& secondPose) {
+    float computeAngleBetweenPoses(const geometry_msgs::msg::PoseStamped& firstPose, const geometry_msgs::msg::PoseStamped& secondPose)
+    {
         float firstPoseAngle = extractYawFromQuaternion(firstPose.pose.orientation);
         float secondPoseAngle = extractYawFromQuaternion(secondPose.pose.orientation);
         float pathAngle = secondPoseAngle - firstPoseAngle;
-        if (pathAngle > M_PI) {
+        if(pathAngle > M_PI)
+        {
             pathAngle -= 2.0 * M_PI;
-        } else if (pathAngle < -M_PI) {
+        }
+        else if(pathAngle < -M_PI)
+        {
             pathAngle += 2 * M_PI;
         }
         return pathAngle;
     }
 
-    void plannedTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped) {
-        if (recording) {
-            if (plannedTrajectory.paths.empty()) {
+    void plannedTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped)
+    {
+        if(recording)
+        {
+            if(plannedTrajectory.paths.empty())
+            {
                 plannedTrajectory.header.frame_id = poseStamped.header.frame_id;
                 plannedTrajectory.header.stamp = this->now();
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
@@ -170,7 +198,9 @@ class WilnNode : public rclcpp::Node {
                 directionalPath.poses.push_back(poseStamped);
                 plannedTrajectory.paths.push_back(directionalPath);
                 publishPlannedTrajectory();
-            } else if (std::fabs(computeAngleBetweenPoses(plannedTrajectory.paths.back().poses.back(), poseStamped)) > 0.5) {
+            }
+            else if(std::fabs(computeAngleBetweenPoses(plannedTrajectory.paths.back().poses.back(), poseStamped)) > 0.5)
+            {
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                 directionalPath.header.frame_id = poseStamped.header.frame_id;
                 directionalPath.header.stamp = this->now();
@@ -180,7 +210,9 @@ class WilnNode : public rclcpp::Node {
                 directionalPath.poses.push_back(rotatedPose);
                 plannedTrajectory.paths.push_back(directionalPath);
                 publishPlannedTrajectory();
-            } else if (lastDrivingDirection.load() != drivingForward.load()) {
+            }
+            else if(lastDrivingDirection.load() != drivingForward.load())
+            {
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                 directionalPath.header.frame_id = poseStamped.header.frame_id;
                 directionalPath.header.stamp = this->now();
@@ -188,12 +220,15 @@ class WilnNode : public rclcpp::Node {
                 directionalPath.poses.push_back(poseStamped);
                 plannedTrajectory.paths.push_back(directionalPath);
                 publishPlannedTrajectory();
-            } else {
+            }
+            else
+            {
                 geometry_msgs::msg::PoseStamped lastPose = plannedTrajectory.paths.back().poses.back();
                 double distance = std::sqrt(std::pow(poseStamped.pose.position.x - lastPose.pose.position.x, 2) +
                                             std::pow(poseStamped.pose.position.y - lastPose.pose.position.y, 2) +
                                             std::pow(poseStamped.pose.position.z - lastPose.pose.position.z, 2));
-                if (distance >= 0.05) {
+                if(distance >= 0.05)
+                {
                     plannedTrajectory.paths.back().poses.push_back(poseStamped);
                     publishPlannedTrajectory();
                 }
@@ -202,9 +237,12 @@ class WilnNode : public rclcpp::Node {
         }
     }
 
-    void realTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped) {
-        if (playing) {
-            if (realTrajectory.paths.empty()) {
+    void realTrajectoryCallback(const geometry_msgs::msg::PoseStamped& poseStamped)
+    {
+        if(playing)
+        {
+            if(realTrajectory.paths.empty())
+            {
                 realTrajectory.header.frame_id = poseStamped.header.frame_id;
                 realTrajectory.header.stamp = this->now();
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
@@ -215,19 +253,20 @@ class WilnNode : public rclcpp::Node {
                 realTrajectory.paths.push_back(directionalPath);
                 publishRealTrajectory();
             }
-            //            else if(std::fabs(computeAngleBetweenPoses(realTrajectory.paths.back().poses.back(), poseStamped)) > 0.5)
-            //            {
-            //                norlab_controllers_msgs::msg::DirectionalPath directionalPath;
-            //                directionalPath.header.frame_id = poseStamped.header.frame_id;
-            //                directionalPath.header.stamp = this->now();
-            //                directionalPath.forward = drivingForward.load();
-            //                geometry_msgs::msg::PoseStamped rotatedPose = poseStamped;
-            //                rotatedPose.pose.position = realTrajectory.paths.back().poses.back().pose.position;
-            //                directionalPath.poses.push_back(rotatedPose);
-            //                realTrajectory.paths.push_back(directionalPath);
-            //                publishRealTrajectory();
-            //            }
-            else if (lastDrivingDirection.load() != drivingForward.load()) {
+//            else if(std::fabs(computeAngleBetweenPoses(realTrajectory.paths.back().poses.back(), poseStamped)) > 0.5)
+//            {
+//                norlab_controllers_msgs::msg::DirectionalPath directionalPath;
+//                directionalPath.header.frame_id = poseStamped.header.frame_id;
+//                directionalPath.header.stamp = this->now();
+//                directionalPath.forward = drivingForward.load();
+//                geometry_msgs::msg::PoseStamped rotatedPose = poseStamped;
+//                rotatedPose.pose.position = realTrajectory.paths.back().poses.back().pose.position;
+//                directionalPath.poses.push_back(rotatedPose);
+//                realTrajectory.paths.push_back(directionalPath);
+//                publishRealTrajectory();
+//            }
+            else if(lastDrivingDirection.load() != drivingForward.load())
+            {
                 norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                 directionalPath.header.frame_id = poseStamped.header.frame_id;
                 directionalPath.header.stamp = this->now();
@@ -235,12 +274,15 @@ class WilnNode : public rclcpp::Node {
                 directionalPath.poses.push_back(poseStamped);
                 realTrajectory.paths.push_back(directionalPath);
                 publishRealTrajectory();
-            } else {
+            }
+            else
+            {
                 geometry_msgs::msg::PoseStamped lastPose = realTrajectory.paths.back().poses.back();
                 double distance = std::sqrt(std::pow(poseStamped.pose.position.x - lastPose.pose.position.x, 2) +
                                             std::pow(poseStamped.pose.position.y - lastPose.pose.position.y, 2) +
                                             std::pow(poseStamped.pose.position.z - lastPose.pose.position.z, 2));
-                if (distance >= 0.05) {
+                if(distance >= 0.05)
+                {
                     realTrajectory.paths.back().poses.push_back(poseStamped);
                     publishRealTrajectory();
                 }
@@ -249,49 +291,61 @@ class WilnNode : public rclcpp::Node {
         }
     }
 
-    void goalResponseCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::SharedPtr& trajectoryGoalHandle) {
-        if (!trajectoryGoalHandle) {
+    void goalResponseCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::SharedPtr& trajectoryGoalHandle)
+    {
+        if(!trajectoryGoalHandle)
+        {
             RCLCPP_ERROR(this->get_logger(), "Goal was rejected by server");
-        } else {
+        }
+        else
+        {
             RCLCPP_INFO(this->get_logger(), "Goal accepted by server, waiting for result");
         }
     }
 
     void trajectoryFeedbackCallback(rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::SharedPtr,
-                                    const std::shared_ptr<const norlab_controllers_msgs::action::FollowPath::Feedback> feedback) {
-        // TODO: program feedback callback
+                                    const std::shared_ptr<const norlab_controllers_msgs::action::FollowPath::Feedback> feedback)
+    {
+        //TODO: program feedback callback
         return;
     }
 
-    void trajectoryResultCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::WrappedResult& trajectory_result) {
+    void trajectoryResultCallback(const rclcpp_action::ClientGoalHandle<norlab_controllers_msgs::action::FollowPath>::WrappedResult& trajectory_result)
+    {
         playing = false;
 
         RCLCPP_WARN(this->get_logger(), "i got in trajectory_result_callback");
 
-        if (trajectory_result.code == rclcpp_action::ResultCode::SUCCEEDED) {
+        if(trajectory_result.code == rclcpp_action::ResultCode::SUCCEEDED)
+        {
             RCLCPP_WARN(this->get_logger(), "Successfully reached goal!");
-        } else {
+        }
+        else
+        {
             RCLCPP_WARN_STREAM(this->get_logger(), "Trajectory goal was not reached.");
         }
     }
 
-    void startRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
-        if (recording) {
+    void startRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+    {
+        if(recording)
+        {
+            res->success = false;
             res->message = "Trajectory is already being recorded.";
-            res->success = false;
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if (playing) {
+        if(playing)
+        {
+            res->success = false;
             res->message = "Cannot start recording, trajectory is currently being played.";
-            res->success = false;
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        res->message = "Recording trajectory.";
         res->success = true;
+        res->message = "Recording trajectory.";
         recording = true;
 
         auto enableMappingRequest = std::make_shared<std_srvs::srv::Trigger::Request>();
@@ -299,15 +353,19 @@ class WilnNode : public rclcpp::Node {
         return;
     }
 
-    norlab_controllers_msgs::msg::PathSequence smoothTrajectoryLowPass(const norlab_controllers_msgs::msg::PathSequence& roughTrajectory) {
+    norlab_controllers_msgs::msg::PathSequence smoothTrajectoryLowPass(const norlab_controllers_msgs::msg::PathSequence& roughTrajectory)
+    {
         norlab_controllers_msgs::msg::PathSequence smoothTrajectory(roughTrajectory);
 
-        for (int i = 0; i < roughTrajectory.paths.size(); ++i) {
-            for (int j = lowPassFilterWindowSize; j < roughTrajectory.paths[i].poses.size() - lowPassFilterWindowSize; ++j) {
+        for(int i = 0; i < roughTrajectory.paths.size(); ++i)
+        {
+            for(int j = lowPassFilterWindowSize; j < roughTrajectory.paths[i].poses.size() - lowPassFilterWindowSize; ++j)
+            {
                 double windowNeighborSumX = 0;
                 double windowNeighborSumY = 0;
                 double windowNeighborSumZ = 0;
-                for (int k = j - lowPassFilterWindowSize; k < j + lowPassFilterWindowSize + 1; ++k) {
+                for(int k = j - lowPassFilterWindowSize; k < j + lowPassFilterWindowSize + 1; ++k)
+                {
                     windowNeighborSumX += roughTrajectory.paths[i].poses[k].pose.position.x;
                     windowNeighborSumY += roughTrajectory.paths[i].poses[k].pose.position.y;
                     windowNeighborSumZ += roughTrajectory.paths[i].poses[k].pose.position.z;
@@ -317,7 +375,8 @@ class WilnNode : public rclcpp::Node {
                 smoothTrajectory.paths[i].poses[j].pose.position.z = windowNeighborSumZ / ((2 * lowPassFilterWindowSize) + 1);
             }
         }
-        for (int i = 0; i < lowPassFilterWindowSize; ++i) {
+        for(int i = 0; i < lowPassFilterWindowSize; ++i)
+        {
             smoothTrajectory.paths.front().poses.erase(smoothTrajectory.paths.front().poses.begin());
             smoothTrajectory.paths.back().poses.erase(smoothTrajectory.paths.back().poses.end() - 1);
         }
@@ -325,79 +384,80 @@ class WilnNode : public rclcpp::Node {
         return smoothTrajectory;
     }
 
-    void stopRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
-        if (!recording) {
-            res->message = "Trajectory is already not being recorded.";
+    void stopRecordingServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+    {
+        if(!recording)
+        {
             res->success = false;
+            res->message = "Trajectory is already not being recorded.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
-
-        res->message = "Stopped recording trajectory.";
+        
         res->success = true;
+        res->message = "Stopped recording trajectory.";
         recording = false;
         return;
     }
 
-    void clearTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
+    void clearTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+    {
         plannedTrajectory.paths.clear();
+        res->success = true;
         res->message = "Cleared planned trajectory.";
-        res->success = true;
         return;
     }
 
-    void smoothTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
+    void smoothTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+    {
         plannedTrajectory = smoothTrajectoryLowPass(plannedTrajectory);
-        res->message = "Smoothed planned trajectory.";
         res->success = true;
+        res->message = "Smoothed planned trajectory.";
         return;
     }
 
-    void cancelTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
-        if (!playing) {
-            res->message = "Cannot cancel trajectory, no trajectory is being played.";
+    void cancelTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+    {
+        if(!playing)
+        {
             res->success = false;
+            res->message = "Cannot cancel trajectory, no trajectory is being played.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        auto future = followPathClient->async_cancel_all_goals();
+        playing = false;
+        res->success = true;
+        res->message = "Cancelled trajectory.";
 
-        rclcpp::FutureReturnCode response = rclcpp::spin_until_future_complete(this->get_node_base_interface(), future);
-        if (response == rclcpp::FutureReturnCode::SUCCESS) {
-            auto responseValue = future.get();
-            if (responseValue->return_code == responseValue->ERROR_NONE) {
-                res->message = "Successfully cancelled trajectory.";
-                res->success = true;
-                playing = false;
-                RCLCPP_INFO(this->get_logger(), "%s", res->message.c_str());
-            } else {
-                res->message = "Failed to cancel trajectory.";
-                res->success = false;
-                RCLCPP_ERROR(this->get_logger(), "%s", res->message.c_str());
-            }
-        }
-
+        // TODO: validate action call here
+        followPathClient->async_cancel_all_goals();
         return;
     }
 
-    double computeEuclideanDistanceBetweenPoses(const geometry_msgs::msg::Pose& firstPose, const geometry_msgs::msg::Pose& secondPose) {
-        return sqrt(pow(firstPose.position.x - secondPose.position.x, 2) + pow(firstPose.position.y - secondPose.position.y, 2) +
+    double computeEuclideanDistanceBetweenPoses(const geometry_msgs::msg::Pose& firstPose, const geometry_msgs::msg::Pose& secondPose)
+    {
+        return sqrt(pow(firstPose.position.x - secondPose.position.x, 2) +
+                    pow(firstPose.position.y - secondPose.position.y, 2) +
                     pow(firstPose.position.z - secondPose.position.z, 2));
     }
 
-    double extractYawFromQuaternion(const geometry_msgs::msg::Quaternion& quaternion) {
+    double extractYawFromQuaternion(const geometry_msgs::msg::Quaternion& quaternion)
+    {
         return std::atan2(2.0f * (quaternion.w * quaternion.z + quaternion.x * quaternion.y),
                           quaternion.w * quaternion.w + quaternion.x * quaternion.x - quaternion.y * quaternion.y - quaternion.z * quaternion.z);
     }
 
-    double computeTrajectoryYaw(const norlab_controllers_msgs::msg::PathSequence& trajectory, const geometry_msgs::msg::Pose& pose) {
+    double computeTrajectoryYaw(const norlab_controllers_msgs::msg::PathSequence& trajectory, const geometry_msgs::msg::Pose& pose)
+    {
         double dx = 0;
         double dy = 0;
         int pathIndex = 0;
-        while (std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && pathIndex < trajectory.paths.size()) {
+        while(std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && pathIndex < trajectory.paths.size())
+        {
             int poseIndex = 0;
-            while (std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && poseIndex < trajectory.paths[pathIndex].poses.size()) {
+            while(std::sqrt(std::pow(dx, 2) + std::pow(dy, 2)) < 1.0 && poseIndex < trajectory.paths[pathIndex].poses.size())
+            {
                 dx = trajectory.paths[pathIndex].poses[poseIndex].pose.position.x - pose.position.x;
                 dy = trajectory.paths[pathIndex].poses[poseIndex].pose.position.y - pose.position.y;
                 ++poseIndex;
@@ -407,14 +467,15 @@ class WilnNode : public rclcpp::Node {
         return std::atan2(dy, dx);
     }
 
-    void saveLTRServiceCallback(const std::shared_ptr<wiln::srv::SaveMapTraj::Request> req, std::shared_ptr<wiln::srv::SaveMapTraj::Response> res) {
-        // TODO: force save to same working repository as mapper
+    void saveLTRServiceCallback(const std::shared_ptr<wiln::srv::SaveMapTraj::Request> req, std::shared_ptr<wiln::srv::SaveMapTraj::Response> res)
+    {
+        //TODO: force save to same working repository as mapper
         using namespace std::chrono_literals;
         auto saveMapRequest = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
         std::string mapName = req->file_name.data.substr(0, req->file_name.data.rfind('.')) + ".vtk";
         saveMapRequest->map_file_name.data = mapName;
-        //        auto saveMapFuture = saveMapClient->async_send_request(saveMapRequest);
-        //        std::shared_ptr<norlab_icp_mapper_ros::srv::SaveMap::Request> request = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
+//        auto saveMapFuture = saveMapClient->async_send_request(saveMapRequest);
+//        std::shared_ptr<norlab_icp_mapper_ros::srv::SaveMap::Request> request = std::make_shared<norlab_icp_mapper_ros::srv::SaveMap::Request>();
         RCLCPP_INFO(this->get_logger(), "calling /save_map");
         norlab_icp_mapper_ros::srv::SaveMap::Response response = rclcpp::call_service<norlab_icp_mapper_ros::srv::SaveMap>("save_map", saveMapRequest);
         RCLCPP_INFO(this->get_logger(), "/save_map done");
@@ -425,27 +486,34 @@ class WilnNode : public rclcpp::Node {
         ltrFile << TRAJECTORY_DELIMITER << std::endl;
         ltrFile << "frame_id : " << plannedTrajectory.paths.front().poses.front().header.frame_id << std::endl;
 
-        for (int i = 0; i < plannedTrajectory.paths.size(); ++i) {
-            for (int j = 0; j < plannedTrajectory.paths[i].poses.size(); ++j) {
-                ltrFile << plannedTrajectory.paths[i].poses[j].pose.position.x << "," << plannedTrajectory.paths[i].poses[j].pose.position.y << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.position.z << "," << plannedTrajectory.paths[i].poses[j].pose.orientation.x << ","
-                        << plannedTrajectory.paths[i].poses[j].pose.orientation.y << "," << plannedTrajectory.paths[i].poses[j].pose.orientation.z << ","
+        for(int i = 0; i < plannedTrajectory.paths.size(); ++i)
+        {
+            for(int j = 0; j < plannedTrajectory.paths[i].poses.size(); ++j)
+            {
+                ltrFile << plannedTrajectory.paths[i].poses[j].pose.position.x << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.position.y << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.position.z << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.orientation.x << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.orientation.y << ","
+                        << plannedTrajectory.paths[i].poses[j].pose.orientation.z << ","
                         << plannedTrajectory.paths[i].poses[j].pose.orientation.w << std::endl;
             }
-            if (i != plannedTrajectory.paths.size() - 1) {
+            if(i != plannedTrajectory.paths.size() - 1)
+            {
                 ltrFile << "changing direction" << std::endl;
             }
         }
 
         ltrFile.close();
 
-        // TODO : handle errors
-        res->message = "LTR file succesfully saved.";
+        // TODO: handle errors
         res->success = true;
+        res->message = "LTR file succesfully saved";
         RCLCPP_INFO(this->get_logger(), "%s", res->message.c_str());
     }
 
-    void loadLTR(std::string fileName, bool fromEnd) {
+    void loadLTR(std::string fileName, bool fromEnd)
+    {
         using namespace std::chrono_literals;
         plannedTrajectory.paths.clear();
         std::ofstream mapFile("/tmp/map.vtk");
@@ -453,19 +521,27 @@ class WilnNode : public rclcpp::Node {
         std::string line;
         std::string pathFrameId;
         bool parsingMap = true;
-        while (std::getline(ltrFile, line)) {
-            if (parsingMap) {
-                if (line.find(TRAJECTORY_DELIMITER) != std::string::npos) {
+        while(std::getline(ltrFile, line))
+        {
+            if(parsingMap)
+            {
+                if(line.find(TRAJECTORY_DELIMITER) != std::string::npos)
+                {
                     std::getline(ltrFile, line);
                     pathFrameId = line.substr(FRAME_ID_START_POSITION);
                     plannedTrajectory.header.frame_id = pathFrameId;
                     plannedTrajectory.header.stamp = this->now();
                     parsingMap = false;
-                } else {
+                }
+                else
+                {
                     mapFile << line << std::endl;
                 }
-            } else {
-                if (plannedTrajectory.paths.empty()) {
+            }
+            else
+            {
+                if(plannedTrajectory.paths.empty())
+                {
                     norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                     directionalPath.header.frame_id = pathFrameId;
                     directionalPath.header.stamp = this->now();
@@ -473,7 +549,8 @@ class WilnNode : public rclcpp::Node {
                     plannedTrajectory.paths.push_back(directionalPath);
                 }
 
-                if (line.find("changing direction") != std::string::npos) {
+                if(line.find("changing direction") != std::string::npos)
+                {
                     norlab_controllers_msgs::msg::DirectionalPath directionalPath;
                     directionalPath.header.frame_id = pathFrameId;
                     directionalPath.header.stamp = this->now();
@@ -517,10 +594,13 @@ class WilnNode : public rclcpp::Node {
 
         int pathIndex;
         int poseIndex;
-        if (!fromEnd) {
+        if(!fromEnd)
+        {
             pathIndex = 0;
             poseIndex = 0;
-        } else {
+        }
+        else
+        {
             pathIndex = plannedTrajectory.paths.size() - 1;
             poseIndex = plannedTrajectory.paths[pathIndex].poses.size() - 1;
         }
@@ -534,7 +614,7 @@ class WilnNode : public rclcpp::Node {
         loadMapRequest->pose.orientation.w = plannedTrajectory.paths[pathIndex].poses[poseIndex].pose.orientation.w;
         loadMapClient->async_send_request(loadMapRequest);
 
-        //        auto loadMapFuture = loadMapClient->async_send_request(loadMapRequest);
+//        auto loadMapFuture = loadMapClient->async_send_request(loadMapRequest);
         RCLCPP_INFO(this->get_logger(), "calling /load_map");
         norlab_icp_mapper_ros::srv::LoadMap::Response response = rclcpp::call_service<norlab_icp_mapper_ros::srv::LoadMap>("load_map", loadMapRequest);
         RCLCPP_INFO(this->get_logger(), "/load_map done");
@@ -544,50 +624,58 @@ class WilnNode : public rclcpp::Node {
         publishPlannedTrajectory();
     }
 
-    void publishPlannedTrajectory() {
+    void publishPlannedTrajectory()
+    {
         auto plannedPath = getNavPathFromPathSequence(plannedTrajectory);
         plannedTrajectoryPublisher->publish(plannedPath);
     }
 
-    void publishRealTrajectory() {
+    void publishRealTrajectory()
+    {
         auto realPath = getNavPathFromPathSequence(realTrajectory);
         realTrajectoryPublisher->publish(realPath);
     }
 
-    void loadLTRServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res) {
+    void loadLTRServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)
+    {
         loadLTR(req->file_name.data, false);
 
         // TODO : handle errors
-        res->message = "Loaded LTR file.";
         res->success = true;
+        res->message = "Loaded LTR file";
         return;
     }
 
-    void loadLTRFromEndServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res) {
+    void loadLTRFromEndServiceCallback(const std::shared_ptr<wiln::srv::LoadMapTraj::Request> req, std::shared_ptr<wiln::srv::LoadMapTraj::Response> res)
+    {
         loadLTR(req->file_name.data, true);
 
         // TODO : handle errors
-        res->message = "Loaded LTR file.";
         res->success = true;
+        res->message = "Loaded LTR file from end";
         return;
     }
 
-    void playLineTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res) {
-        if (playing) {
+    void playLineTrajectoryServiceCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req, std::shared_ptr<std_srvs::srv::Trigger::Response> res)
+    {
+        if(playing)
+        {
             res->success = false;
             res->message = "Trajectory is already being played.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if (recording) {
+        if(recording)
+        {
             res->success = false;
             res->message = "Cannot play trajectory while recording.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if (plannedTrajectory.paths.empty() || plannedTrajectory.paths.front().poses.empty()) {
+        if(plannedTrajectory.paths.empty() || plannedTrajectory.paths.front().poses.empty())
+        {
             res->success = false;
             res->message = "Cannot play an empty trajectory.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
@@ -601,16 +689,19 @@ class WilnNode : public rclcpp::Node {
         double robotPoseToTrajectoryStartDistance = computeEuclideanDistanceBetweenPoses(robotPose, trajectory.paths.front().poses.front().pose);
         double robotPoseToTrajectoryEndDistance = computeEuclideanDistanceBetweenPoses(robotPose, trajectory.paths.back().poses.back().pose);
 
-        RCLCPP_INFO_STREAM(this->get_logger(), "distance to start " << robotPoseToTrajectoryStartDistance);
-        RCLCPP_INFO_STREAM(this->get_logger(), "distance to end " << robotPoseToTrajectoryEndDistance);
+        RCLCPP_INFO_STREAM(this->get_logger(), "distance to start "<<robotPoseToTrajectoryStartDistance);
+        RCLCPP_INFO_STREAM(this->get_logger(), "distance to end "<<robotPoseToTrajectoryEndDistance);
 
-        if (robotPoseToTrajectoryEndDistance < robotPoseToTrajectoryStartDistance) {
+        if(robotPoseToTrajectoryEndDistance < robotPoseToTrajectoryStartDistance)
+        {
             tf2::Quaternion robotOrientation;
 
             std::reverse(trajectory.paths.begin(), trajectory.paths.end());
-            for (int i = 0; i < trajectory.paths.size(); ++i) {
+            for(int i = 0; i < trajectory.paths.size(); ++i)
+            {
                 std::reverse(trajectory.paths[i].poses.begin(), trajectory.paths[i].poses.end());
-                for (int j = 0; j < trajectory.paths[i].poses.size(); ++j) {
+                for(int j = 0; j < trajectory.paths[i].poses.size(); ++j)
+                {
                     tf2::fromMsg(trajectory.paths[i].poses[j].pose.orientation, robotOrientation);
                     trajectory.paths[i].poses[j].pose.orientation = tf2::toMsg((HALF_TURN_ROTATION * robotOrientation).normalized());
                 }
@@ -620,16 +711,20 @@ class WilnNode : public rclcpp::Node {
         double robotPoseYaw = extractYawFromQuaternion(robotPose.orientation);
         double trajectoryStartYaw = computeTrajectoryYaw(trajectory, robotPose);
         double angleDistance = std::fabs(trajectoryStartYaw - robotPoseYaw);
-        if (angleDistance > M_PI) {
+        if(angleDistance > M_PI)
+        {
             angleDistance = (2 * M_PI) - angleDistance;
         }
 
-        if (angleDistance > M_PI_2) {
+        if(angleDistance > M_PI_2)
+        {
             tf2::Quaternion robotOrientation;
 
-            for (int i = 0; i < trajectory.paths.size(); ++i) {
+            for(int i = 0; i < trajectory.paths.size(); ++i)
+            {
                 trajectory.paths[i].forward = !plannedTrajectory.paths[i].forward;
-                for (int j = 0; j < trajectory.paths[i].poses.size(); ++j) {
+                for(int j = 0; j < trajectory.paths[i].poses.size(); ++j)
+                {
                     tf2::fromMsg(trajectory.paths[i].poses[j].pose.orientation, robotOrientation);
                     trajectory.paths[i].poses[j].pose.orientation = tf2::toMsg((HALF_TURN_ROTATION * robotOrientation).normalized());
                 }
@@ -646,39 +741,44 @@ class WilnNode : public rclcpp::Node {
 
         // TODO: validate action call
         auto goal_msg = norlab_controllers_msgs::action::FollowPath::Goal();
-        goal_msg.follower_options.init_mode.data = 1;  // init_mode = 1 : continue
+        goal_msg.follower_options.init_mode.data = 1; // init_mode = 1 : continue
         goal_msg.follower_options.velocity.data = trajectorySpeed;
         goal_msg.path = trajectory;
         goal_msg.path.header.frame_id = trajectory.paths.front().poses.front().header.frame_id;
         goal_msg.path.header.stamp = this->now();
 
         auto send_goal_options = rclcpp_action::Client<norlab_controllers_msgs::action::FollowPath>::SendGoalOptions();
-        send_goal_options.goal_response_callback = std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
-        send_goal_options.feedback_callback = std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
-        send_goal_options.result_callback = std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
+        send_goal_options.goal_response_callback =
+                std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
+        send_goal_options.feedback_callback =
+                std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
+        send_goal_options.result_callback =
+                std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
         followPathClient->async_send_goal(goal_msg, send_goal_options);
 
-        res->success = true;
-        res->message = "Playing trajectory.";
         return;
     }
 
-    void playLoopTrajectoryServiceCallback(const std::shared_ptr<wiln::srv::PlayLoop::Request> req, std::shared_ptr<wiln::srv::PlayLoop::Response> res) {
-        if (playing) {
+    void playLoopTrajectoryServiceCallback(const std::shared_ptr<wiln::srv::PlayLoop::Request> req, std::shared_ptr<wiln::srv::PlayLoop::Response> res)
+    {
+        if(playing)
+        {
             res->success = false;
             res->message = "Trajectory is already being played.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if (recording) {
+        if(recording)
+        {
             res->success = false;
             res->message = "Cannot play trajectory while recording.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
             return;
         }
 
-        if (plannedTrajectory.paths.empty()) {
+        if(plannedTrajectory.paths.empty())
+        {
             res->success = false;
             res->message = "Cannot play an empty trajectory.";
             RCLCPP_WARN(this->get_logger(), "%s", res->message.c_str());
@@ -687,29 +787,28 @@ class WilnNode : public rclcpp::Node {
 
         norlab_controllers_msgs::msg::PathSequence cutLoopTrajectory = plannedTrajectory;
         int poseIndex = cutLoopTrajectory.paths.back().poses.size() - 1;
-        while (poseIndex >= 1 && computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex - 1].pose,
-                                                                      cutLoopTrajectory.paths.front().poses.front().pose) <
-                                     computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex].pose,
-                                                                          cutLoopTrajectory.paths.front().poses.front().pose)) {
+        while(poseIndex >= 1 && computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex - 1].pose, cutLoopTrajectory.paths.front().poses.front().pose) <
+                                computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses[poseIndex].pose, cutLoopTrajectory.paths.front().poses.front().pose))
+        {
             cutLoopTrajectory.paths.back().poses.erase(cutLoopTrajectory.paths.back().poses.begin() + poseIndex);
             --poseIndex;
         }
         norlab_controllers_msgs::msg::PathSequence firstLoopTrajectory = cutLoopTrajectory;
-        while (firstLoopTrajectory.paths.front().poses.size() > 0 &&
-               computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses.back().pose, firstLoopTrajectory.paths.back().poses.back().pose) <
-                   1.0) {
+        while(firstLoopTrajectory.paths.front().poses.size() > 0 &&
+              computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.back().poses.back().pose, firstLoopTrajectory.paths.back().poses.back().pose) < 1.0)
+        {
             firstLoopTrajectory.paths.front().poses.erase(firstLoopTrajectory.paths.back().poses.end() - 1);
         }
         norlab_controllers_msgs::msg::PathSequence lastLoopTrajectory = cutLoopTrajectory;
-        while (lastLoopTrajectory.paths.front().poses.size() > 0 &&
-               computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, lastLoopTrajectory.paths.front().poses.front().pose) <
-                   1.0) {
+        while(lastLoopTrajectory.paths.front().poses.size() > 0 &&
+              computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, lastLoopTrajectory.paths.front().poses.front().pose) < 1.0)
+        {
             lastLoopTrajectory.paths.front().poses.erase(lastLoopTrajectory.paths.front().poses.begin());
         }
         norlab_controllers_msgs::msg::PathSequence middleLoopTrajectory = firstLoopTrajectory;
-        while (middleLoopTrajectory.paths.front().poses.size() > 0 &&
-               computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, middleLoopTrajectory.paths.front().poses.front().pose) <
-                   1.0) {
+        while(middleLoopTrajectory.paths.front().poses.size() > 0 &&
+              computeEuclideanDistanceBetweenPoses(cutLoopTrajectory.paths.front().poses.front().pose, middleLoopTrajectory.paths.front().poses.front().pose) < 1.0)
+        {
             middleLoopTrajectory.paths.front().poses.erase(middleLoopTrajectory.paths.front().poses.begin());
         }
 
@@ -722,57 +821,80 @@ class WilnNode : public rclcpp::Node {
 
         // TODO: validate action call
         auto goal_msg = norlab_controllers_msgs::action::FollowPath::Goal();
-        goal_msg.follower_options.init_mode.data = 1;  // init_mode = 1 : continue
+        goal_msg.follower_options.init_mode.data = 1; // init_mode = 1 : continue
         goal_msg.follower_options.velocity.data = trajectorySpeed;
         goal_msg.path.header.frame_id = plannedTrajectory.paths.front().poses.front().header.frame_id;
         goal_msg.path.header.stamp = this->now();
-        for (int i = 0; i < firstLoopTrajectory.paths.size(); ++i) {
-            if (i != 0 && firstLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward) {
-                for (int j = 0; j < firstLoopTrajectory.paths[i].poses.size(); ++j) {
+        for(int i = 0; i < firstLoopTrajectory.paths.size(); ++i)
+        {
+            if(i != 0 && firstLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward)
+            {
+                for(int j = 0; j < firstLoopTrajectory.paths[i].poses.size(); ++j)
+                {
                     goal_msg.path.paths.back().poses.push_back(firstLoopTrajectory.paths[i].poses[j]);
                 }
-            } else {
+            }
+            else
+            {
                 goal_msg.path.paths.push_back(firstLoopTrajectory.paths[i]);
             }
         }
-        for (int i = 1; i < req->nb_loops.data - 1; ++i) {
-            for (int j = 0; j < middleLoopTrajectory.paths.size(); ++j) {
-                if (middleLoopTrajectory.paths[j].forward == goal_msg.path.paths.back().forward) {
-                    for (int k = 0; k < middleLoopTrajectory.paths[j].poses.size(); ++k) {
+        for(int i = 1; i < req->nb_loops.data - 1; ++i)
+        {
+            for(int j = 0; j < middleLoopTrajectory.paths.size(); ++j)
+            {
+                if(middleLoopTrajectory.paths[j].forward == goal_msg.path.paths.back().forward)
+                {
+                    for(int k = 0; k < middleLoopTrajectory.paths[j].poses.size(); ++k)
+                    {
                         goal_msg.path.paths.back().poses.push_back(middleLoopTrajectory.paths[j].poses[k]);
                     }
-                } else {
+                }
+                else
+                {
                     goal_msg.path.paths.push_back(middleLoopTrajectory.paths[j]);
                 }
             }
         }
 
-        for (int i = 0; i < lastLoopTrajectory.paths.size(); ++i) {
-            if (lastLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward) {
-                for (int j = 0; j < lastLoopTrajectory.paths[i].poses.size(); ++j) {
+        for(int i = 0; i < lastLoopTrajectory.paths.size(); ++i)
+        {
+            if(lastLoopTrajectory.paths[i].forward == goal_msg.path.paths.back().forward)
+            {
+                for(int j = 0; j < lastLoopTrajectory.paths[i].poses.size(); ++j)
+                {
                     goal_msg.path.paths.back().poses.push_back(lastLoopTrajectory.paths[i].poses[j]);
                 }
-            } else {
+            }
+            else
+            {
                 goal_msg.path.paths.push_back(lastLoopTrajectory.paths[i]);
             }
         }
 
         auto send_goal_options = rclcpp_action::Client<norlab_controllers_msgs::action::FollowPath>::SendGoalOptions();
-        send_goal_options.goal_response_callback = std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
-        send_goal_options.feedback_callback = std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
-        send_goal_options.result_callback = std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
+        send_goal_options.goal_response_callback =
+                std::bind(&WilnNode::goalResponseCallback, this, std::placeholders::_1);
+        send_goal_options.feedback_callback =
+                std::bind(&WilnNode::trajectoryFeedbackCallback, this, std::placeholders::_1, std::placeholders::_2);
+        send_goal_options.result_callback =
+                std::bind(&WilnNode::trajectoryResultCallback, this, std::placeholders::_1);
         followPathClient->async_send_goal(goal_msg);
 
         res->success = true;
-        res->message = "Playing loop trajectory.";
+        res->message = "Playing loop trajectory";
+
         return;
     }
 
-    nav_msgs::msg::Path getNavPathFromPathSequence(const norlab_controllers_msgs::msg::PathSequence& pathSequence) {
+    nav_msgs::msg::Path getNavPathFromPathSequence(const norlab_controllers_msgs::msg::PathSequence& pathSequence)
+    {
         nav_msgs::msg::Path navPath;
         navPath.header = pathSequence.header;
-        for (const auto& path : pathSequence.paths) {
-            for (const geometry_msgs::msg::PoseStamped& poseStamped : path.poses) {
+        for(const auto& path: pathSequence.paths)
+        {
+            for(const geometry_msgs::msg::PoseStamped& poseStamped: path.poses)
+            {
                 navPath.poses.push_back(poseStamped);
             }
         }
@@ -780,9 +902,10 @@ class WilnNode : public rclcpp::Node {
     }
 };
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
     rclcpp::init(argc, argv);
-    //    rclcpp::spin(std::make_shared<WilnNode>());
+//    rclcpp::spin(std::make_shared<WilnNode>());
     rclcpp::executors::MultiThreadedExecutor executor;
     auto wiln_node = std::make_shared<WilnNode>();
     executor.add_node(wiln_node);

--- a/src/wiln_node.cpp
+++ b/src/wiln_node.cpp
@@ -351,10 +351,15 @@ private:
         if(trajectory_result.code == rclcpp_action::ResultCode::SUCCEEDED)
         {
             RCLCPP_WARN(this->get_logger(), "Successfully reached goal!");
+
+            status.status = IDLE;
         }
         else
         {
             RCLCPP_WARN_STREAM(this->get_logger(), "Trajectory goal was not reached.");
+
+            status.status = IDLE;
+            setTemporaryStatus(false, "Trajectory goal was not reached.");
         }
     }
 

--- a/srv/LoadMapTraj.srv
+++ b/srv/LoadMapTraj.srv
@@ -1,2 +1,4 @@
 std_msgs/String file_name
 ---
+bool success
+string message

--- a/srv/PlayLoop.srv
+++ b/srv/PlayLoop.srv
@@ -1,2 +1,4 @@
 std_msgs/UInt32 nb_loops
 ---
+bool success
+string message

--- a/srv/SaveMapTraj.srv
+++ b/srv/SaveMapTraj.srv
@@ -1,2 +1,4 @@
 std_msgs/String file_name
 ---
+bool success
+string message


### PR DESCRIPTION
# Improving usability of wiln

## Why?
To improve usability I created a [foxglove interface](https://github.com/norlab-ulaval/wiln/pull/21/files#diff-f6aea56b51a43d9e27fe2ab90f60222dd8909d5d9b6af29d08f8a484c9bedf99) where we can easily call the services and have good feedback on wheter it works or not.

The foxglove interface is named `Warthog_TnR_Foxglove.json`.

## How ?
I added proper responses to every services in wiln.
:warning: There is still a few that I assume will work. We should do some error checking on those. (Link in comments)

I also added a status publisher to be able to see in which state wiln is curently in. It's a more complete version of this [PR](https://github.com/norlab-ulaval/wiln/pull/14)

## Tests
:heavy_check_mark:  I tested : 
1. Start recording
2. Stop recording
3. Cancel trajectory
4. Play trajectory once
5. Clear trajectory

:warning:  not tested : 
1. Save LTR
2. Load LTR
3. Play loop trajectory