### PR TITLE
Remove service caller dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(nav_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(norlab_icp_mapper_ros REQUIRED)
 find_package(norlab_controllers_msgs REQUIRED)
-find_package(service_caller REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
 include_directories(include)
@@ -37,7 +36,6 @@ ament_target_dependencies(wiln_node
     rclcpp_action
     norlab_icp_mapper_ros
     norlab_controllers_msgs
-    service_caller
     tf2_geometry_msgs
 )
 

--- a/include/wiln.hpp
+++ b/include/wiln.hpp
@@ -10,7 +10,6 @@
 #include <wiln/srv/play_loop.hpp>
 #include <norlab_icp_mapper_ros/srv/save_map.hpp>
 #include <norlab_icp_mapper_ros/srv/load_map.hpp>
-#include <service_caller/ServiceCaller.hpp>
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>

--- a/package.xml
+++ b/package.xml
@@ -44,7 +44,6 @@
   <depend>tf2</depend>
   <depend>norlab_icp_mapper_ros</depend>
   <depend>norlab_controllers_msgs</depend>
-  <depend>service_caller</depend>
   <depend>tf2_geometry_msgs</depend>
 
   <build_depend>rosidl_default_generators</build_depend>

--- a/wiln.repos
+++ b/wiln.repos
@@ -19,7 +19,3 @@ repositories:
     type: git
     url: git@github.com:norlab-ulaval/pointcloud_motion_deskew.git
     version: humble
-  service_caller:
-    type: git
-    url: git@github.com:norlab-ulaval/service_caller.git
-    version: master


### PR DESCRIPTION
This PR removes the [service caller](https://github.com/norlab-ulaval/service_caller) dependency that wasn't being used anywhere in the project.